### PR TITLE
Feat: Создать модели для чата в Prisma и Добавить WebSocket подключение (#320, #321)

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -3,6 +3,7 @@ import fastifyCookie from '@fastify/cookie'
 import fastifyCors from '@fastify/cors'
 import fastifyStatic from '@fastify/static'
 import path from 'path'
+import { Server as SocketIOServer } from 'socket.io'
 
 import { errorHandler } from './middleware/globalErrorHandler.js'
 

--- a/backend/middleware/socketAuth.ts
+++ b/backend/middleware/socketAuth.ts
@@ -1,0 +1,57 @@
+import { Socket } from 'socket.io'
+import { verifyAccessToken } from '../services/token.service.js'
+import { prisma } from '../prisma.js'
+
+export interface AuthenticatedSocket extends Socket {
+	user: {
+		id: string
+		role: 'CLIENT' | 'TRAINER'
+	}
+}
+
+export const socketAuthMiddleware = async (
+	socket: Socket,
+	next: (err?: Error) => void,
+) => {
+	const token = socket.handshake.auth.token
+
+	if (!token) {
+		return next(new Error('Токен отсутствует'))
+	}
+
+	try {
+		const payload = verifyAccessToken(token)
+
+		// Проверяем refreshToken в БД
+		const refreshToken = socket.handshake.auth.refreshToken
+		if (!refreshToken) {
+			return next(new Error('Refresh токен отсутствует'))
+		}
+
+		const tokenInDb = await prisma.refreshToken.findUnique({
+			where: {
+				id: payload.refreshTokenId,
+				token: refreshToken,
+			},
+		})
+
+		if (!tokenInDb) {
+			return next(new Error('Токены не связаны'))
+		}
+
+		// Проверяем пользователя
+		const user = await prisma.user.findUnique({
+			where: { id: payload.user.id },
+			select: { id: true, role: true },
+		})
+
+		if (!user) {
+			return next(new Error('Пользователь не найден'))
+		}
+
+		;(socket as AuthenticatedSocket).user = user
+		next()
+	} catch (err) {
+		next(new Error('Неверный токен'))
+	}
+}

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,10 +20,12 @@
 				"fastify": "5.6.2",
 				"fastify-type-provider-zod": "6.1.0",
 				"jsonwebtoken": "9.0.2",
+				"socket.io": "4.7.5",
 				"zod": "4.1.12"
 			},
 			"devDependencies": {
 				"@types/jsonwebtoken": "9.0.10",
+				"@types/socket.io": "3.0.2",
 				"nodemon": "3.1.11",
 				"prisma": "6.19.0",
 				"ts-node": "10.9.2",
@@ -968,6 +970,12 @@
 				"@prisma/debug": "6.19.0"
 			}
 		},
+		"node_modules/@socket.io/component-emitter": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+			"integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+			"license": "MIT"
+		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
@@ -1083,6 +1091,21 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/cookie": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+			"integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+			"license": "MIT"
+		},
+		"node_modules/@types/cors": {
+			"version": "2.8.19",
+			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+			"integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/jsonwebtoken": {
 			"version": "9.0.10",
 			"resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
@@ -1116,6 +1139,17 @@
 			"integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
 			"license": "MIT"
 		},
+		"node_modules/@types/socket.io": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-3.0.2.tgz",
+			"integrity": "sha512-pu0sN9m5VjCxBZVK8hW37ZcMe8rjn4HHggBN5CbaRTvFwv5jOmuIRZEuddsBPa9Th0ts0SIo3Niukq+95cMBbQ==",
+			"deprecated": "This is a stub types definition. socket.io provides its own type definitions, so you do not need this installed.",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"socket.io": "*"
+			}
+		},
 		"node_modules/@types/ws": {
 			"version": "8.18.1",
 			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -1130,6 +1164,19 @@
 			"resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
 			"integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
 			"license": "MIT"
+		},
+		"node_modules/accepts": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+			"integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-types": "~2.1.34",
+				"negotiator": "0.6.3"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
 		},
 		"node_modules/acorn": {
 			"version": "8.15.0",
@@ -1260,6 +1307,15 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/base64id": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+			"integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+			"license": "MIT",
+			"engines": {
+				"node": "^4.5.0 || >= 5.9"
+			}
 		},
 		"node_modules/bcryptjs": {
 			"version": "3.0.3",
@@ -1474,6 +1530,19 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
+		"node_modules/cors": {
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+			"license": "MIT",
+			"dependencies": {
+				"object-assign": "^4",
+				"vary": "^1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
 		"node_modules/create-require": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -1617,6 +1686,83 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=14"
+			}
+		},
+		"node_modules/engine.io": {
+			"version": "6.5.5",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.5.tgz",
+			"integrity": "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/cookie": "^0.4.1",
+				"@types/cors": "^2.8.12",
+				"@types/node": ">=10.0.0",
+				"accepts": "~1.3.4",
+				"base64id": "2.0.0",
+				"cookie": "~0.4.1",
+				"cors": "~2.8.5",
+				"debug": "~4.3.1",
+				"engine.io-parser": "~5.2.1",
+				"ws": "~8.17.1"
+			},
+			"engines": {
+				"node": ">=10.2.0"
+			}
+		},
+		"node_modules/engine.io-parser": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+			"integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/engine.io/node_modules/cookie": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/engine.io/node_modules/debug": {
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+			"integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/engine.io/node_modules/ws": {
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+			"integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/esbuild": {
@@ -2296,6 +2442,27 @@
 				"node": ">=10.0.0"
 			}
 		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/minimatch": {
 			"version": "10.1.1",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
@@ -2325,6 +2492,15 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"license": "MIT"
+		},
+		"node_modules/negotiator": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
 		},
 		"node_modules/node-fetch-native": {
 			"version": "1.6.7",
@@ -2403,6 +2579,15 @@
 			},
 			"engines": {
 				"node": "^14.16.0 || >=16.10.0"
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/ohash": {
@@ -2955,6 +3140,119 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/socket.io": {
+			"version": "4.7.5",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.5.tgz",
+			"integrity": "sha512-DmeAkF6cwM9jSfmp6Dr/5/mfMwb5Z5qRrSXLpo3Fq5SqyU8CMF15jIN4ZhfSwu35ksM1qmHZDQ/DK5XTccSTvA==",
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "~1.3.4",
+				"base64id": "~2.0.0",
+				"cors": "~2.8.5",
+				"debug": "~4.3.2",
+				"engine.io": "~6.5.2",
+				"socket.io-adapter": "~2.5.2",
+				"socket.io-parser": "~4.2.4"
+			},
+			"engines": {
+				"node": ">=10.2.0"
+			}
+		},
+		"node_modules/socket.io-adapter": {
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+			"integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "~4.3.4",
+				"ws": "~8.17.1"
+			}
+		},
+		"node_modules/socket.io-adapter/node_modules/debug": {
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+			"integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/socket.io-adapter/node_modules/ws": {
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+			"integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/socket.io-parser": {
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+			"integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+			"license": "MIT",
+			"dependencies": {
+				"@socket.io/component-emitter": "~3.1.0",
+				"debug": "~4.3.1"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/socket.io-parser/node_modules/debug": {
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+			"integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/socket.io/node_modules/debug": {
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+			"integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/sonic-boom": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
@@ -3254,6 +3552,15 @@
 			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
 		},
 		"node_modules/which": {
 			"version": "2.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,10 +28,12 @@
 		"fastify": "5.6.2",
 		"fastify-type-provider-zod": "6.1.0",
 		"jsonwebtoken": "9.0.2",
+		"socket.io": "4.7.5",
 		"zod": "4.1.12"
 	},
 	"devDependencies": {
 		"@types/jsonwebtoken": "9.0.10",
+		"@types/socket.io": "3.0.2",
 		"nodemon": "3.1.11",
 		"prisma": "6.19.0",
 		"ts-node": "10.9.2",

--- a/backend/prisma/migrations/20251210085446_add_chat_models/migration.sql
+++ b/backend/prisma/migrations/20251210085446_add_chat_models/migration.sql
@@ -1,0 +1,50 @@
+-- CreateTable
+CREATE TABLE "Chat" (
+    "id" TEXT NOT NULL,
+    "trainerId" TEXT NOT NULL,
+    "clientId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Chat_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Message" (
+    "id" TEXT NOT NULL,
+    "chatId" TEXT NOT NULL,
+    "senderId" TEXT NOT NULL,
+    "text" TEXT NOT NULL,
+    "imageUrl" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "isRead" BOOLEAN NOT NULL DEFAULT false,
+
+    CONSTRAINT "Message_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Chat_trainerId_idx" ON "Chat"("trainerId");
+
+-- CreateIndex
+CREATE INDEX "Chat_clientId_idx" ON "Chat"("clientId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Chat_trainerId_clientId_key" ON "Chat"("trainerId", "clientId");
+
+-- CreateIndex
+CREATE INDEX "Message_chatId_idx" ON "Message"("chatId");
+
+-- CreateIndex
+CREATE INDEX "Message_senderId_idx" ON "Message"("senderId");
+
+-- AddForeignKey
+ALTER TABLE "Chat" ADD CONSTRAINT "Chat_trainerId_fkey" FOREIGN KEY ("trainerId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Chat" ADD CONSTRAINT "Chat_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Message" ADD CONSTRAINT "Message_chatId_fkey" FOREIGN KEY ("chatId") REFERENCES "Chat"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Message" ADD CONSTRAINT "Message_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -57,6 +57,11 @@ model User {
   // 🔽 связи для питания
   nutritionCategories  NutritionCategory[]   @relation("UserNutritionCategories")
   clientNutritionPlans ClientNutritionPlan[]
+
+  // 🔽 связи для чата
+  chatsAsTrainer Chat[]    @relation("ChatTrainer")
+  chatsAsClient  Chat[]    @relation("ChatClient")
+  messages       Message[]
 }
 
 model RefreshToken {
@@ -231,4 +236,39 @@ model ClientNutritionPlan {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+}
+
+//
+// ======= Чат =======
+//
+
+model Chat {
+  id        String   @id @default(cuid())
+  trainerId String
+  trainer   User     @relation("ChatTrainer", fields: [trainerId], references: [id], onDelete: Cascade)
+  clientId  String
+  client    User     @relation("ChatClient", fields: [clientId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  messages Message[]
+
+  @@unique([trainerId, clientId])
+  @@index([trainerId])
+  @@index([clientId])
+}
+
+model Message {
+  id        String   @id @default(cuid())
+  chatId    String
+  chat      Chat     @relation(fields: [chatId], references: [id], onDelete: Cascade)
+  senderId  String
+  sender    User     @relation(fields: [senderId], references: [id], onDelete: Cascade)
+  text      String
+  imageUrl  String?
+  createdAt DateTime @default(now())
+  isRead    Boolean  @default(false)
+
+  @@index([chatId])
+  @@index([senderId])
 }

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -1,10 +1,54 @@
 import app from './app.js'
+import { Server as SocketIOServer } from 'socket.io'
+import { socketAuthMiddleware, AuthenticatedSocket } from './middleware/socketAuth.js'
 
 const PORT = process.env.PORT ? Number(process.env.PORT) : 3000
 
 const start = async () => {
 	try {
-		await app.listen({ port: PORT, host: '0.0.0.0' })
+		const server = await app.listen({ port: PORT, host: '0.0.0.0' })
+
+		// Настройка Socket.IO
+		const io = new SocketIOServer(app.server, {
+			cors: {
+				origin: process.env.FRONTEND_URL || 'http://localhost:5173',
+				credentials: true,
+			},
+		})
+
+		// Middleware для аутентификации
+		io.use(socketAuthMiddleware)
+
+		// Обработка подключений
+		io.on('connection', (socket) => {
+			const authSocket = socket as AuthenticatedSocket
+			console.log(`Пользователь ${authSocket.user.id} подключился`)
+
+			// Присоединение к комнате чата
+			authSocket.on('join_chat', (chatId: string) => {
+				authSocket.join(`chat_${chatId}`)
+				console.log(`Пользователь ${authSocket.user.id} присоединился к чату ${chatId}`)
+			})
+
+			// Индикатор печати
+			authSocket.on('typing_start', (chatId: string) => {
+				authSocket.to(`chat_${chatId}`).emit('user_typing', {
+					userId: authSocket.user.id,
+					chatId,
+				})
+			})
+
+			authSocket.on('typing_stop', (chatId: string) => {
+				authSocket.to(`chat_${chatId}`).emit('user_stopped_typing', {
+					userId: authSocket.user.id,
+					chatId,
+				})
+			})
+
+			authSocket.on('disconnect', () => {
+				console.log(`Пользователь ${authSocket.user.id} отключился`)
+			})
+		})
 
 		console.log(`Сервер работает на порту ${PORT}`)
 	} catch (err) {


### PR DESCRIPTION
Что было сделано:

- Добавил модели `Chat` и `Message` в `prisma/schema.prisma` с отношениями к `User` (trainer/client)
- Поля Chat: id, trainerId, clientId, createdAt, updatedAt
- Поля Message: id, chatId, senderId, text, imageUrl (опционально), createdAt, isRead
- Созданы и применины миграции (при запуске проект вам нужно применить эти миграции `npm run prisma:migrate:dev`, `npm run prisma:generate`)
- Установлен socket.io в `package.json` и импортирован в `app.ts` (вам нужно установить `cd backend`, `npm install`)
- Настроен WebSocket сервер в `server.ts` с аутентификацией через JWT (использован `token.service.ts`)
- Обработаны подключения: валидация токена, присоединение к комнате чата
- Добавлен middleware для WebSocket в `middleware/`