### PR TITLE
Feat: Подготовить Frontend к интеграции чата. (#332, #333)

### DIFF
--- a/frontend/src/components/Chat/Chat.tsx
+++ b/frontend/src/components/Chat/Chat.tsx
@@ -15,25 +15,43 @@ const getInitialMessages = (role: 'client' | 'trainer'): MessageType[] => {
 	if (role === 'client') {
 		return [
 			{
-				id: 1,
+				id: 'demo-1',
+				chatId: 'demo-chat',
+				senderId: 'trainer',
 				text: 'Здравствуйте! Я ваш тренер. Готов помочь вам достичь ваших целей! 💪',
 				createdAt: '10:00',
-				sender: 'trainer',
+				isRead: true,
+				sender: {
+					id: 'trainer',
+					name: 'Тренер',
+				},
 			},
 			{
-				id: 2,
+				id: 'demo-2',
+				chatId: 'demo-chat',
+				senderId: 'trainer',
 				text: 'Как прошла ваша тренировка на этой неделе?',
 				createdAt: '10:01',
-				sender: 'trainer',
+				isRead: true,
+				sender: {
+					id: 'trainer',
+					name: 'Тренер',
+				},
 			},
 		]
 	}
 	return [
 		{
-			id: 1,
+			id: 'demo-3',
+			chatId: 'demo-chat',
+			senderId: 'client',
 			text: 'Здравствуйте! Я записался к вам на тренировки',
 			createdAt: '09:30',
-			sender: 'client',
+			isRead: true,
+			sender: {
+				id: 'client',
+				name: 'Клиент',
+			},
 		},
 	]
 }
@@ -44,11 +62,7 @@ type ChatProps = {
 	partnerName?: string // Имя собеседника
 }
 
-export const Chat: React.FC<ChatProps> = ({
-	role,
-	chatId: propChatId,
-	partnerName,
-}) => {
+export const Chat: React.FC<ChatProps> = ({ role, chatId: propChatId, partnerName }) => {
 	// Формируем chatId
 	const chatId = propChatId || (role === 'client' ? 'client_trainer' : 'trainer_client')
 
@@ -89,7 +103,7 @@ export const Chat: React.FC<ChatProps> = ({
 			if (e.target?.result) {
 				setFileList([
 					{
-						uid: info.file.uid ? Number(info.file.uid) : Date.now(),
+						uid: info.file.uid,
 						name: info.file.name,
 						url: e.target.result as string,
 					},
@@ -120,13 +134,16 @@ export const Chat: React.FC<ChatProps> = ({
 		}
 
 		const newMessage: MessageType = {
-			id: Date.now(),
+			id: 'temp-' + Date.now().toString(),
+			chatId,
+			senderId: role,
 			text,
-			createdAt: new Date().toLocaleTimeString('ru-RU', {
-				hour: '2-digit',
-				minute: '2-digit',
-			}),
-			sender: role,
+			createdAt: new Date().toISOString(),
+			isRead: true,
+			sender: {
+				id: role,
+				name: role === 'client' ? 'Клиент' : 'Тренер',
+			},
 			imageUrl,
 		}
 
@@ -145,7 +162,10 @@ export const Chat: React.FC<ChatProps> = ({
 		year: 'numeric',
 	})
 
-	const title = role === 'client' ? 'Чат с тренером' : `Чат с клиентом${partnerName ? `: ${partnerName}` : ''}`
+	const title =
+		role === 'client'
+			? 'Чат с тренером'
+			: `Чат с клиентом${partnerName ? `: ${partnerName}` : ''}`
 
 	return (
 		<div

--- a/frontend/src/components/Chat/Message.tsx
+++ b/frontend/src/components/Chat/Message.tsx
@@ -12,7 +12,7 @@ export const Message: React.FC<MessageProps> = ({ msg, onPreview, role }) => (
 	<div
 		className={clsx(
 			'w-fit min-w-[120px] max-w-[65%] px-4 py-3',
-			msg.sender === role ? 'ml-auto' : 'mr-auto',
+			msg.sender.id === role ? 'ml-auto' : 'mr-auto',
 		)}
 		style={{
 			borderRadius: 15,

--- a/frontend/src/types/client-chat.ts
+++ b/frontend/src/types/client-chat.ts
@@ -1,13 +1,59 @@
 export type ChatUploadFile = {
-	uid: number
+	uid: string
 	name: string
 	url: string
 }
 
 export type MessageType = {
-	id: number
+	id: string
+	chatId: string
+	senderId: string
 	text: string
-	createdAt: string
-	sender: 'client' | 'trainer'
 	imageUrl?: string
+	createdAt: string
+	isRead: boolean
+	sender: {
+		id: string
+		name: string
+		photo?: string
+	}
+}
+
+export type ChatType = {
+	id: string
+	trainerId: string
+	clientId: string
+	createdAt: string
+	updatedAt: string
+	client?: {
+		id: string
+		name: string
+		photo?: string
+	}
+	trainer?: {
+		id: string
+		name: string
+		photo?: string
+	}
+	lastMessage?: MessageType | null
+	unreadCount: number
+	isFavorite?: boolean
+}
+
+export type ChatListResponse = {
+	chats: ChatType[]
+}
+
+export type MessagesResponse = {
+	messages: MessageType[]
+	pagination: {
+		page: number
+		limit: number
+		total: number
+		totalPages: number
+	}
+}
+
+export type SendMessageResponse = {
+	message: MessageType
 }


### PR DESCRIPTION
Что было сделано:

- Обновлён `chat.api.ts` для соответствия текущему бэкенду API:

> - Изменён endpoints на: `getChats: GET /chat`s (список чатов с непрочитанными)
> - getMessages: `GET /chat/:chatId/messages` (история с пагинацией)
> - sendMessage: `POST /chat/:chatId/messages` (отправка текста/изображения)

- Обновлены типы запросов/ответов согласно бэкенду
- Удалены устаревшие endpoints `markMessagesAsRead`, `getTrainerChats`
- Синхронизированы типы в `client-chat.ts` с бэкендом
- Изменён `MessageType.id` с number на `string` (CUID)
- Добавлено поля: `senderId`, `isRead`, `imageUrl?`
- Добавлены типы для API ответов (список чатов, пагинация)