### PR TITLE
Feat: Интеграция WebSocket и API во фронтовый чат-компонент (#334, #335)

### DIFF
--- a/backend/middleware/socketAuth.ts
+++ b/backend/middleware/socketAuth.ts
@@ -1,6 +1,7 @@
 import { Socket } from 'socket.io'
 import { verifyAccessToken } from '../services/token.service.js'
 import { prisma } from '../prisma.js'
+import cookie from 'cookie'
 
 export interface AuthenticatedSocket extends Socket {
 	user: {
@@ -22,8 +23,9 @@ export const socketAuthMiddleware = async (
 	try {
 		const payload = verifyAccessToken(token)
 
-		// Проверяем refreshToken в БД
-		const refreshToken = socket.handshake.auth.refreshToken
+		// Проверяем refreshToken из cookies
+		const cookies = cookie.parse(socket.handshake.headers.cookie || '')
+		const refreshToken = cookies.refreshToken
 		if (!refreshToken) {
 			return next(new Error('Refresh токен отсутствует'))
 		}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
 				"react-redux": "9.2.0",
 				"react-router-dom": "7.9.6",
 				"recharts": "3.4.1",
+				"socket.io-client": "^4.8.1",
 				"tailwindcss": "4.1.17"
 			},
 			"devDependencies": {
@@ -1598,6 +1599,12 @@
 				"win32"
 			]
 		},
+		"node_modules/@socket.io/component-emitter": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+			"integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+			"license": "MIT"
+		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
@@ -3123,6 +3130,45 @@
 				"react": ">=16"
 			}
 		},
+		"node_modules/engine.io-client": {
+			"version": "6.6.3",
+			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
+			"integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
+			"license": "MIT",
+			"dependencies": {
+				"@socket.io/component-emitter": "~3.1.0",
+				"debug": "~4.3.1",
+				"engine.io-parser": "~5.2.1",
+				"ws": "~8.17.1",
+				"xmlhttprequest-ssl": "~2.1.1"
+			}
+		},
+		"node_modules/engine.io-client/node_modules/debug": {
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+			"integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/engine.io-parser": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+			"integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
 		"node_modules/enhanced-resolve": {
 			"version": "5.18.3",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
@@ -4174,7 +4220,6 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
@@ -5285,6 +5330,68 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/socket.io-client": {
+			"version": "4.8.1",
+			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+			"integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@socket.io/component-emitter": "~3.1.0",
+				"debug": "~4.3.2",
+				"engine.io-client": "~6.6.1",
+				"socket.io-parser": "~4.2.4"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/socket.io-client/node_modules/debug": {
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+			"integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/socket.io-parser": {
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+			"integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+			"license": "MIT",
+			"dependencies": {
+				"@socket.io/component-emitter": "~3.1.0",
+				"debug": "~4.3.1"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/socket.io-parser/node_modules/debug": {
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+			"integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5700,6 +5807,35 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/ws": {
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+			"integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/xmlhttprequest-ssl": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+			"integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+			"engines": {
+				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/yallist": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
 		"react-redux": "9.2.0",
 		"react-router-dom": "7.9.6",
 		"recharts": "3.4.1",
+		"socket.io-client": "^4.8.1",
 		"tailwindcss": "4.1.17"
 	},
 	"devDependencies": {

--- a/frontend/src/components/Chat/InputPanel.tsx
+++ b/frontend/src/components/Chat/InputPanel.tsx
@@ -18,6 +18,7 @@ type InputPanelProps = {
 	onEmojiSelect: (emoji: string) => void
 	onSend: () => void
 	disabledSend: boolean
+	loading?: boolean
 }
 
 export const InputPanel: React.FC<InputPanelProps> = ({
@@ -33,6 +34,7 @@ export const InputPanel: React.FC<InputPanelProps> = ({
 	onEmojiSelect,
 	onSend,
 	disabledSend,
+	loading = false,
 }) => (
 	<>
 		<Form
@@ -162,6 +164,7 @@ export const InputPanel: React.FC<InputPanelProps> = ({
 				htmlType='submit'
 				size='large'
 				disabled={disabledSend}
+				loading={loading}
 				style={{
 					borderRadius: 16,
 					padding: '0 28px',

--- a/frontend/src/utils/socket.ts
+++ b/frontend/src/utils/socket.ts
@@ -1,0 +1,137 @@
+import { io, Socket } from 'socket.io-client'
+import { API_BASE_URL } from '../config/api.config'
+import type { MessageType } from '../types'
+
+export interface ServerToClientEvents {
+	new_message: (message: MessageType) => void
+	user_typing: (data: { chatId: string; userId: string }) => void
+	user_stopped_typing: (data: { chatId: string; userId: string }) => void
+}
+
+export interface ClientToServerEvents {
+	join_chat: (chatId: string) => void
+	leave_chat: (chatId: string) => void
+	typing_start: (chatId: string) => void
+	typing_stop: (chatId: string) => void
+}
+
+class SocketService {
+	private socket: Socket<ServerToClientEvents, ClientToServerEvents> | null = null
+	private reconnectAttempts = 0
+	private maxReconnectAttempts = 5
+	private reconnectDelay = 1000
+
+	connect(): Promise<void> {
+		return new Promise((resolve, reject) => {
+			if (this.socket?.connected) {
+				resolve()
+				return
+			}
+
+			const token = localStorage.getItem('token')
+			if (!token) {
+				reject(new Error('No access token found'))
+				return
+			}
+
+			this.socket = io(API_BASE_URL, {
+				auth: {
+					token,
+				},
+				transports: ['websocket', 'polling'],
+				upgrade: true,
+				rememberUpgrade: true,
+				timeout: 20000,
+			})
+
+			this.socket.on('connect', () => {
+				console.log('Socket connected:', this.socket?.id)
+				this.reconnectAttempts = 0
+				resolve()
+			})
+
+			this.socket.on('disconnect', (reason) => {
+				console.log('Socket disconnected:', reason)
+				if (reason === 'io server disconnect') {
+					// Сервер отключил, не переподключаемся автоматически
+					this.socket?.disconnect()
+				} else {
+					// Попытка переподключения
+					this.handleReconnect()
+				}
+			})
+
+			this.socket.on('connect_error', (error) => {
+				console.error('Socket connection error:', error)
+				this.handleReconnect()
+				if (this.reconnectAttempts >= this.maxReconnectAttempts) {
+					reject(error)
+				}
+			})
+
+			this.socket.on('new_message', (message) => {
+				console.log('New message received:', message)
+				// Обработка нового сообщения через колбэки
+			})
+
+			this.socket.on('user_typing', (data) => {
+				console.log('User typing:', data)
+			})
+
+			this.socket.on('user_stopped_typing', (data) => {
+				console.log('User stopped typing:', data)
+			})
+		})
+	}
+
+	private handleReconnect() {
+		if (this.reconnectAttempts < this.maxReconnectAttempts) {
+			this.reconnectAttempts++
+			setTimeout(() => {
+				console.log(
+					`Attempting to reconnect... (${this.reconnectAttempts}/${this.maxReconnectAttempts})`,
+				)
+				this.socket?.connect()
+			}, this.reconnectDelay * this.reconnectAttempts)
+		}
+	}
+
+	disconnect() {
+		if (this.socket) {
+			this.socket.disconnect()
+			this.socket = null
+		}
+	}
+
+	// Методы для отправки событий
+	joinChat(chatId: string) {
+		this.socket?.emit('join_chat', chatId)
+	}
+
+	leaveChat(chatId: string) {
+		this.socket?.emit('leave_chat', chatId)
+	}
+
+	startTyping(chatId: string) {
+		this.socket?.emit('typing_start', chatId)
+	}
+
+	stopTyping(chatId: string) {
+		this.socket?.emit('typing_stop', chatId)
+	}
+
+	// Подписка на события (использовать напрямую socket.on в компонентах)
+	getSocket() {
+		return this.socket
+	}
+
+	get isConnected(): boolean {
+		return this.socket?.connected ?? false
+	}
+
+	get socketId(): string | undefined {
+		return this.socket?.id
+	}
+}
+
+export const socketService = new SocketService()


### PR DESCRIPTION
Что было сделано:

- Синхронизированы типы в client-chat.ts с бэкендом.
- Поле MessageType.id изменено с number на string (CUID).
- Добавлены поля senderId, isRead, imageUrl? в сообщения.
- Обновлён тип ChatUploadFile.
- Добавлены типы для API-ответов: список чатов и пагинация.
- Установлен socket.io-client и создан сервис utils/socket.ts. (Установить новый пакет - `cd frontend`, `npm install`)
- Настроена аутентификация WebSocket через access/refresh токены.
- Реализованы подписки на события: new_message, typing_start, typing_stop.
- Добавлена обработка подключения, отключения и автоматического переподключения.