### PR TITLE
refactor: #343 styles

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -39,7 +39,7 @@
 		},
 		"node_modules/@babel/helper-string-parser": {
 			"version": "7.27.1",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -47,7 +47,7 @@
 		},
 		"node_modules/@babel/helper-validator-identifier": {
 			"version": "7.28.5",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -55,7 +55,7 @@
 		},
 		"node_modules/@babel/parser": {
 			"version": "7.28.5",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/types": "^7.28.5"
@@ -69,7 +69,7 @@
 		},
 		"node_modules/@babel/types": {
 			"version": "7.28.5",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.27.1",
@@ -98,6 +98,74 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+			"integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+			"integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+			"integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+			"integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@esbuild/darwin-arm64": {
 			"version": "0.25.12",
 			"cpu": [
@@ -108,6 +176,363 @@
 			"optional": true,
 			"os": [
 				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+			"integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+			"integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+			"integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+			"integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+			"integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+			"integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+			"integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+			"integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+			"integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+			"integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+			"integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+			"integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+			"integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+			"integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+			"integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+			"integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+			"integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+			"integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+			"integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+			"integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+			"integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
 			],
 			"engines": {
 				"node": ">=18"
@@ -531,6 +956,34 @@
 				"@prisma/debug": "6.19.0"
 			}
 		},
+		"node_modules/@rollup/rollup-android-arm-eabi": {
+			"version": "4.53.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
+			"integrity": "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-android-arm64": {
+			"version": "4.53.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.3.tgz",
+			"integrity": "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
 			"version": "4.53.3",
 			"cpu": [
@@ -541,6 +994,272 @@
 			"optional": true,
 			"os": [
 				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-x64": {
+			"version": "4.53.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.3.tgz",
+			"integrity": "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-arm64": {
+			"version": "4.53.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.3.tgz",
+			"integrity": "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-x64": {
+			"version": "4.53.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.3.tgz",
+			"integrity": "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+			"version": "4.53.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.3.tgz",
+			"integrity": "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
+			"version": "4.53.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.3.tgz",
+			"integrity": "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-gnu": {
+			"version": "4.53.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.3.tgz",
+			"integrity": "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-musl": {
+			"version": "4.53.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.3.tgz",
+			"integrity": "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-gnu": {
+			"version": "4.53.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.3.tgz",
+			"integrity": "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
+			"version": "4.53.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.3.tgz",
+			"integrity": "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
+			"version": "4.53.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.3.tgz",
+			"integrity": "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-musl": {
+			"version": "4.53.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.3.tgz",
+			"integrity": "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-s390x-gnu": {
+			"version": "4.53.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.3.tgz",
+			"integrity": "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-gnu": {
+			"version": "4.53.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz",
+			"integrity": "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-musl": {
+			"version": "4.53.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz",
+			"integrity": "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-openharmony-arm64": {
+			"version": "4.53.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.3.tgz",
+			"integrity": "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-arm64-msvc": {
+			"version": "4.53.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.3.tgz",
+			"integrity": "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-ia32-msvc": {
+			"version": "4.53.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.3.tgz",
+			"integrity": "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-gnu": {
+			"version": "4.53.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.3.tgz",
+			"integrity": "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-msvc": {
+			"version": "4.53.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz",
+			"integrity": "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
 			]
 		},
 		"node_modules/@socket.io/component-emitter": {
@@ -2085,18 +2804,6 @@
 				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
-		"node_modules/magicast": {
-			"version": "0.3.5",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@babel/parser": "^7.25.4",
-				"@babel/types": "^7.25.4",
-				"source-map-js": "^1.2.0"
-			}
-		},
 		"node_modules/make-dir": {
 			"version": "4.0.0",
 			"dev": true,
@@ -2933,7 +3640,7 @@
 		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
-			"dev": true,
+			"devOptional": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"

--- a/frontend/src/components/Admin/AllClientsGrid.tsx
+++ b/frontend/src/components/Admin/AllClientsGrid.tsx
@@ -94,7 +94,16 @@ export const AllClientsGrid: React.FC<AllClientsGridProps> = () => {
 		switch (status) {
 			case 'ACCEPTED':
 				return (
-					<Tag icon={<CheckCircleOutlined />} color='success' style={{ marginLeft: 8 }}>
+					<Tag 
+						icon={<CheckCircleOutlined />} 
+						style={{ 
+							marginLeft: 8,
+							background: 'var(--success)',
+							borderColor: 'var(--success)',
+							color: '#fff',
+							fontWeight: 600
+						}}
+					>
 						В работе
 					</Tag>
 				)

--- a/frontend/src/components/Admin/CreateDayForm.tsx
+++ b/frontend/src/components/Admin/CreateDayForm.tsx
@@ -242,13 +242,15 @@ export const CreateDayForm = ({
 				Добавить прием пищи
 			</Button>
 
-			<Form.Item className='mt-6 mb-0'>
-				<Space>
-					<Button onClick={onCancel}>Отмена</Button>
-					<Button type='primary' htmlType='submit'>
+			<Form.Item className='mt-8 mb-4 pt-6 pb-2 border-t border-gray-200'>
+				<div className='flex justify-end gap-3'>
+					<Button onClick={onCancel} size='large'>
+						Отмена
+					</Button>
+					<Button type='primary' htmlType='submit' size='large'>
 						{day ? 'Сохранить изменения' : 'Создать день'}
 					</Button>
-				</Space>
+				</div>
 			</Form.Item>
 		</Form>
 	)

--- a/frontend/src/components/Admin/CreateDayForm.tsx
+++ b/frontend/src/components/Admin/CreateDayForm.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Form, Input, Button, Card, Space, Select } from 'antd'
+import { Form, Input, Button, Card, Select } from 'antd'
 import { PlusOutlined, DeleteOutlined } from '@ant-design/icons'
 import type { NutritionMeal, NutritionDay, MealType } from '../../types/nutritions'
 import { mealTypes } from '../../constants/mealTypes'

--- a/frontend/src/components/Admin/DayCard.tsx
+++ b/frontend/src/components/Admin/DayCard.tsx
@@ -40,7 +40,7 @@ export const DayCard = ({ day, openedDayId, onDayClick, onEditDay }: DayCardProp
 
 	return (
 		<Card
-			className='background-light border-muted cursor-pointer hover:shadow-md transition-shadow'
+			className='bg-light border-muted cursor-pointer hover:shadow-md transition-shadow'
 			onClick={() => onDayClick(day.id)}
 		>
 			<div className='flex justify-between items-center'>

--- a/frontend/src/components/Admin/NutritionCategoryCard.tsx
+++ b/frontend/src/components/Admin/NutritionCategoryCard.tsx
@@ -68,8 +68,8 @@ export const NutritionCategoryCard = ({
 	return (
 		<Card
 			hoverable
-			className={`nutrition-category-card border-muted hover:shadow-lg transition-all duration-300 background-light relative ${
-				openedCategoryId === category.id ? 'expanded' : ''
+			className={`border-muted hover:shadow-lg transition-all duration-300 bg-light relative min-h-[120px] ${
+				openedCategoryId === category.id ? 'min-h-[300px]' : ''
 			}`}
 			onClick={handleCardClick}
 		>
@@ -93,7 +93,7 @@ export const NutritionCategoryCard = ({
 					<div className='flex justify-between items-center'>
 						<div className='flex items-center gap-2'>
 							<span className='text-lg'>{getCategoryIcon(category.id)}</span>
-							<span className='text-custom hover-info-custom cursor-pointer'>
+							<span className='text-gray-800 hover:text-blue-500 cursor-pointer transition-colors'>
 								{category.name}
 							</span>
 						</div>

--- a/frontend/src/components/Common/Header.tsx
+++ b/frontend/src/components/Common/Header.tsx
@@ -79,7 +79,7 @@ export function Header() {
 	// Загрузка данных пользователя
 	if (token && isLoading) {
 		return (
-			<header className="border-b border-muted background-light">
+			<header className="border-b border-muted bg-light">
 				<div className="flex h-16 items-center justify-between px-6">
 					<Link to="/" className="text-xl font-bold text-gray-800">
 						Fitness App
@@ -96,7 +96,7 @@ export function Header() {
 	// Неавторизованный пользователь (нет токена или нет данных)
 	if (!isAuthenticated) {
 		return (
-			<header className="border-b border-muted background-light">
+			<header className="border-b border-muted bg-light">
 				<div className="flex h-16 items-center justify-between px-6">
 					<Link to="/" className="text-xl font-bold text-gray-800">
 						Fitness App
@@ -124,7 +124,7 @@ export function Header() {
 		const isNutritionActive = location.pathname.startsWith('/me/nutrition')
 
 		return (
-			<header className="border-b border-muted background-light">
+			<header className="border-b border-muted bg-light">
 				<div className="flex h-16 items-center justify-between px-6">
 					<nav className="flex items-center gap-6 h-full">
 						<Link
@@ -135,11 +135,7 @@ export function Header() {
 						</Link>
 						<Link
 							to="/"
-							className="relative text-sm font-medium transition-colors h-full flex items-center"
-							style={{
-								color: isHomeActive ? '#2563eb' : '#4b5563',
-								fontWeight: isHomeActive ? 600 : 500,
-							}}
+							className={`relative text-sm transition-colors h-full flex items-center ${isHomeActive ? 'text-blue-600 font-semibold' : 'text-gray-600 font-medium'}`}
 						>
 							Главная
 							{isHomeActive && (
@@ -148,11 +144,7 @@ export function Header() {
 						</Link>
 						<Link
 							to="/me/nutrition"
-							className="relative text-sm font-medium transition-colors h-full flex items-center"
-							style={{
-								color: isNutritionActive ? '#2563eb' : '#4b5563',
-								fontWeight: isNutritionActive ? 600 : 500,
-							}}
+							className={`relative text-sm transition-colors h-full flex items-center ${isNutritionActive ? 'text-blue-600 font-semibold' : 'text-gray-600 font-medium'}`}
 						>
 							Питание
 							{isNutritionActive && (
@@ -161,11 +153,7 @@ export function Header() {
 						</Link>
 						<Link
 							to="/me/progress"
-							className="relative text-sm font-medium transition-colors h-full flex items-center"
-							style={{
-								color: isProgressActive ? '#2563eb' : '#4b5563',
-								fontWeight: isProgressActive ? 600 : 500,
-							}}
+							className={`relative text-sm transition-colors h-full flex items-center ${isProgressActive ? 'text-blue-600 font-semibold' : 'text-gray-600 font-medium'}`}
 						>
 							Прогресс
 							{isProgressActive && (
@@ -174,11 +162,7 @@ export function Header() {
 						</Link>
 						<Link
 							to="/me/progress/reports"
-							className="relative text-sm font-medium transition-colors h-full flex items-center"
-							style={{
-								color: isReportsActive ? '#2563eb' : '#4b5563',
-								fontWeight: isReportsActive ? 600 : 500,
-							}}
+							className={`relative text-sm transition-colors h-full flex items-center ${isReportsActive ? 'text-blue-600 font-semibold' : 'text-gray-600 font-medium'}`}
 						>
 							Отчёты
 							{isReportsActive && (
@@ -192,11 +176,7 @@ export function Header() {
 						{hasTrainer && (
 							<Link
 								to="/trainer"
-								className="relative flex items-center gap-2 text-sm font-medium transition-colors h-full"
-								style={{
-									color: isTrainerChatActive ? '#2563eb' : '#4b5563',
-									fontWeight: isTrainerChatActive ? 600 : 500,
-								}}
+								className={`relative flex items-center gap-2 text-sm transition-colors h-full ${isTrainerChatActive ? 'text-blue-600 font-semibold' : 'text-gray-600 font-medium'}`}
 							>
 								<Badge count={unreadMessages} size="small" offset={[2, -2]}>
 									<MessageOutlined className="text-lg" />
@@ -230,7 +210,7 @@ export function Header() {
 
 	// Тренер
 	return (
-		<header className="border-b border-muted background-light">
+		<header className="border-b border-muted bg-light">
 			<div className="flex h-16 items-center justify-between px-6">
 				<nav className="flex items-center gap-6 h-full">
 					<Link
@@ -241,11 +221,7 @@ export function Header() {
 					</Link>
 					<Link
 						to="/admin"
-						className="relative text-sm font-medium transition-colors h-full flex items-center"
-						style={{
-							color: isAdminActive ? '#2563eb' : '#4b5563',
-							fontWeight: isAdminActive ? 600 : 500,
-						}}
+						className={`relative text-sm transition-colors h-full flex items-center ${isAdminActive ? 'text-blue-600 font-semibold' : 'text-gray-600 font-medium'}`}
 					>
 						Панель тренера
 						{isAdminActive && (
@@ -254,11 +230,7 @@ export function Header() {
 					</Link>
 					<Link
 						to="/admin/nutrition"
-						className="relative text-sm font-medium transition-colors h-full flex items-center"
-						style={{
-							color: isNutritionTrainerActive ? '#2563eb' : '#4b5563',
-							fontWeight: isNutritionTrainerActive ? 600 : 500,
-						}}
+						className={`relative text-sm transition-colors h-full flex items-center ${isNutritionTrainerActive ? 'text-blue-600 font-semibold' : 'text-gray-600 font-medium'}`}
 					>
 						Планы питания
 						{isNutritionTrainerActive && (

--- a/frontend/src/components/errors/UnauthorizedState.tsx
+++ b/frontend/src/components/errors/UnauthorizedState.tsx
@@ -5,8 +5,8 @@ export const UnauthorizedState = () => {
 	const navigate = useNavigate()
 
 	return (
-		<div className='page-container gradient-bg'>
-			<div className='page-card' style={{ maxWidth: '500px' }}>
+		<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+			<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[500px]'>
 				<Result
 					status='403'
 					title='Требуется авторизация'

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,14 +1,24 @@
 @import 'tailwindcss';
 
+/* ===========================
+   CSS ПЕРЕМЕННЫЕ ТЕМЫ
+   =========================== */
 :root {
+	/* Фоны */
 	--bg-dark: oklch(25% 0.02 260);
 	--bg: oklch(98% 0.005 260);
 	--bg-light: oklch(100% 0 0);
+
+	/* Текст */
 	--text: oklch(25% 0.01 260);
 	--text-muted: oklch(45% 0.005 260);
 	--highlight: oklch(100% 0 0);
+
+	/* Границы */
 	--border: oklch(85% 0.01 260);
 	--border-muted: oklch(90% 0.005 260);
+
+	/* Цвета акцентов */
 	--primary: oklch(60% 0.18 230);
 	--secondary: oklch(70% 0.15 200);
 	--accent: oklch(65% 0.15 270);
@@ -16,17 +26,19 @@
 	--success: oklch(65% 0.18 145);
 	--warning: oklch(75% 0.18 85);
 	--danger: oklch(65% 0.2 25);
+
+	/* Градиенты */
 	--gradient-start: oklch(70% 0.15 230);
 	--gradient-end: oklch(65% 0.15 270);
 }
 
-/* === ОСНОВНЫЕ СТИЛИ === */
+/* ===========================
+   БАЗОВЫЕ СТИЛИ
+   =========================== */
 body {
 	margin: 0;
 	background-color: var(--bg);
 	color: var(--text);
-	height: auto;
-	overflow: auto;
 }
 
 a {
@@ -38,410 +50,47 @@ a:hover {
 	color: inherit;
 }
 
-/* === КОМПОНЕНТЫ СТРАНИЦ === */
-.gradient-bg {
+/* ===========================
+   TAILWIND УТИЛИТЫ
+   =========================== */
+@utility gradient-bg {
 	background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
 	background-attachment: fixed;
 	min-height: 100vh;
-	/* Фикс для прокручиваемого контента - фон покрывает весь контент */
 	background-size: cover;
 }
 
-.page-container {
-	min-height: calc(100vh - 4rem);
-	padding: 40px 20px;
-	display: flex;
-	justify-content: center;
-	align-items: flex-start;
-}
-
-.page-card {
-	background: var(--bg-light);
-	border-radius: 20px;
-	padding: 40px;
-	box-shadow: 0 20px 60px rgba(0, 0, 0, 0.1);
-	border: 1px solid var(--border);
-	width: 100%;
-	max-width: 1200px;
-}
-
-.card-hover {
-	transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-	box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-}
-
-.card-hover:hover {
-	transform: translateY(-4px);
-	box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
-}
-
-.section-header {
-	text-align: center;
-	margin-bottom: 32px;
-}
-
-.section-title {
-	color: var(--text);
-	font-weight: 600;
-	margin-bottom: 16px;
-	padding-bottom: 12px;
-	border-bottom: 3px solid var(--primary);
-	display: inline-block;
-}
-
-/* === ФОРМЫ И ИНПУТЫ === */
-.ant-form {
-	background: transparent !important;
-	border: none !important;
-	box-shadow: none !important;
-	padding: 0 !important;
-}
-
-.auth-container {
-	min-height: calc(100vh - 4rem);
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	padding: 20px;
-}
-
-.auth-card {
-	background: var(--bg-light);
-	border-radius: 20px;
-	padding: 40px;
-	box-shadow: 0 20px 60px rgba(0, 0, 0, 0.1);
-	border: 1px solid var(--border);
-	max-width: 480px;
-	width: 100%;
-}
-
-.form-section {
-	margin-bottom: 32px;
-}
-
-.photo-upload-grid {
-	display: grid;
-	grid-template-columns: 1fr 1fr;
-	gap: 16px;
-	margin-bottom: 24px;
-}
-
-.upload-area {
-	border: 2px dashed var(--border);
-	border-radius: 12px;
-	padding: 20px;
-	text-align: center;
-	cursor: pointer;
-	transition: all 0.3s ease;
-	background: var(--bg);
-}
-
-.upload-area:hover {
-	border-color: var(--primary);
-	background: var(--bg-light);
-}
-
-.upload-preview {
-	width: 100%;
-	height: 120px;
-	object-fit: cover;
-	border-radius: 8px;
-	margin-top: 8px;
-}
-
-/* === ANT DESIGN КОМПОНЕНТЫ === */
-.ant-layout-header,
-.ant-card-head,
-.ant-modal-header,
-.ant-drawer-header {
-	background-color: var(--bg-light) !important;
-}
-
-.ant-form-item-label > label {
-	color: var(--text) !important;
-}
-
-.ant-btn {
-	border-radius: 8px !important;
-	background: var(--bg-light);
-	color: var(--text);
-	border-color: var(--border);
-}
-
-.ant-btn:hover,
-.ant-btn:focus {
-	color: var(--info);
-	border-color: var(--info);
-}
-
-.ant-btn-primary {
-	background: var(--primary) !important;
-	color: var(--highlight) !important;
-	border-color: var(--primary) !important;
-}
-
-.ant-btn-primary:hover,
-.ant-btn-primary:focus {
-	background: var(--info) !important;
-	color: var(--highlight) !important;
-	border-color: var(--info) !important;
-}
-
-.ant-input,
-.ant-input-number .ant-input-number-input,
-.ant-picker,
-.ant-select .ant-select-selector {
-	border-radius: 8px !important;
-	background: var(--bg-light) !important;
-	color: var(--text) !important;
-}
-
-.ant-form-item-explain-error {
-	color: var(--danger) !important;
-}
-
-.ant-form-item-has-error .ant-input,
-.ant-form-item-has-error .ant-input-number,
-.ant-form-item-has-error .ant-picker,
-.ant-form-item-has-error .ant-select .ant-select-selector {
-	border-color: var(--danger) !important;
-}
-
-/* === SELECT И DROPDOWN === */
-.ant-select-dropdown {
-	background: var(--bg-light) !important;
-	border: 1px solid var(--border) !important;
-	border-radius: 12px !important;
-	box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15) !important;
-}
-
-.ant-select-item {
-	background: var(--bg-light) !important;
-	color: var(--text) !important;
-	border-radius: 6px !important;
-	margin: 2px 8px !important;
-	transition: all 0.2s ease !important;
-}
-
-.ant-select-item:hover,
-.ant-select-item-option-selected,
-.ant-select-item-option-active {
-	background: var(--primary) !important;
-	color: var(--highlight) !important;
-}
-
-/* === DATEPICKER === */
-.ant-picker-dropdown {
-	background: var(--bg-light) !important;
-	border: 1px solid var(--border) !important;
-	border-radius: 12px !important;
-}
-
-.ant-picker-cell-selected .ant-picker-cell-inner {
-	background: var(--primary) !important;
-	color: var(--highlight) !important;
-}
-
-/* === УТИЛИТЫ === */
-.text-muted {
-	color: var(--text-muted);
-}
-
-.background-light {
+@utility bg-light {
 	background-color: var(--bg-light);
 }
 
-.border-muted {
+@utility bg-main {
+	background-color: var(--bg);
+}
+
+@utility text-muted {
+	color: var(--text-muted);
+}
+
+@utility border-muted {
 	border-color: var(--border-muted);
 }
 
-.report-card {
-	background: var(--bg);
-	border: 1px solid var(--border);
-	border-radius: 12px;
-	transition: all 0.3s ease;
-	cursor: pointer;
-}
-
-.report-card:hover {
-	transform: translateY(-2px);
-	box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1);
-	border-color: var(--primary);
-}
-
-.filter-tabs {
-	display: flex;
-	gap: 16px;
-	margin-bottom: 32px;
-	justify-content: center;
-}
-
-.filter-tab {
-	padding: 12px 24px;
-	border: 2px solid transparent;
-	border-radius: 8px;
-	background: var(--bg);
-	color: var(--text);
-	cursor: pointer;
-	transition: all 0.3s ease;
-	font-weight: 500;
-}
-
-.filter-tab.active {
-	background: var(--primary);
-	color: var(--highlight);
-	border-color: var(--primary);
-}
-
-.filter-tab:hover:not(.active) {
-	border-color: var(--primary);
+@utility text-primary {
 	color: var(--primary);
 }
 
-.admin-layout {
-	min-height: 100vh;
+@utility text-danger {
+	color: var(--danger);
 }
 
-.admin-sidebar {
-	background: var(--bg-light) !important;
-	border-right: 1px solid var(--border) !important;
-	box-shadow: 2px 0 10px rgba(0, 0, 0, 0.1);
+@utility border-primary {
+	border-color: var(--primary);
 }
 
-.admin-content {
-	background: transparent !important;
-	padding: 0 !important;
-}
-
-/* Стили для Nutrition страницы */
-.nutrition-category-wrapper {
-	min-height: 120px; /* Минимальная высота для закрытой карточки */
-}
-
-.nutrition-category-card {
-	height: auto;
-	min-height: 120px;
-	transition: all 0.3s ease;
-	margin-bottom: 0;
-}
-
-.nutrition-category-card.expanded {
-	min-height: 300px; /* Минимальная высота для открытой карточки */
-}
-
-/* Убираем стандартные отступы Ant Design Card */
-.nutrition-category-card .ant-card-body {
-	padding: 16px !important;
-}
-
-/* Фиксируем высоту заголовка карточки */
-.nutrition-category-card .ant-card-meta {
-	min-height: 60px;
-}
-
-/* Стили для содержимого когда карточка открыта */
-.nutrition-category-card.expanded .ant-card-meta-description {
-	max-height: none;
-	overflow: visible;
-}
-
-/* Убираем стандартный ховер Ant Design */
-.nutrition-category-card.ant-card-hoverable:hover {
-	transform: none;
-	box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-}
-
-.nutrition-category-card:hover {
-	transform: translateY(-2px);
-	box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15);
-}
-
-/* Исправляем grid layout */
-.grid.grid-cols-1.md\:grid-cols-2.lg\:grid-cols-3.gap-6 {
-	grid-auto-rows: minmax(120px, auto);
-	align-items: start;
-}
-
-/* Специальные стили для страницы Admin */
-.admin-page-card {
-	background: var(--bg-light);
-	padding: 40px;
-	box-shadow: 0 20px 60px rgba(0, 0, 0, 0.1);
-	width: 100%;
-	box-sizing: border-box;
-}
-
-/* Убираем ограничение максимальной ширины только для админской страницы */
-.admin-layout .admin-page-card {
-	max-width: none;
-	min-height: 100%;
-}
-
-/* Фиксируем высоту layout и делаем прокрутку в content */
-.admin-layout {
-	height: 100vh;
-	overflow: hidden;
-}
-
-/* Sidebar занимает всю высоту */
-.admin-layout .ant-layout-sider {
-	height: 100vh;
-	overflow-y: auto;
-}
-
-/* Content прокручивается и имеет фон */
-.admin-content {
-	height: 100vh;
-	overflow-y: auto;
-	background: transparent !important;
-}
-
-/* Фикс для вкладки "Все клиенты" - фон не должен обрываться */
-.admin-page-card .ant-tabs-content {
-	min-height: auto;
-}
-
-.admin-page-card .ant-tabs-tabpane {
-	padding-bottom: 40px;
-}
-.custom-segmented {
-	background: transparent;
-}
-.custom-segmented .ant-segmented-item {
-	background-color: lightgray; /* цвет фона всех табов */
-	color: black; /* цвет текста */
-	border-radius: 8px; /* например, радиус */
-}
-/* Отступы между табами кроме последнего элемента */
-.custom-segmented .ant-segmented-item:not(:last-child) {
-	margin-right: 8px; /* отступ между табами */
-}
-.custom-segmented .ant-segmented-item-selected {
-	background-color: #1890ff; /* цвет активного таба */
-	color: white;
-}
-
-/* === КАРТОЧКИ ТРЕНЕРОВ === */
-.trainer-list-card {
-	background: var(--bg-light);
-	transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.trainer-list-card:hover {
-	transform: translateY(-8px);
-	box-shadow: 0 20px 40px rgba(102, 126, 234, 0.25);
-}
-
-.my-trainer-card {
-	transition: all 0.3s ease;
-}
-
-.my-trainer-card:hover {
-	transform: translateY(-4px);
-	box-shadow: 0 25px 70px rgba(102, 126, 234, 0.5);
-}
-
-/* Социальные ссылки */
+/* ===========================
+   СОЦИАЛЬНЫЕ ССЫЛКИ
+   =========================== */
 .social-link {
 	display: inline-flex;
 	align-items: center;
@@ -449,7 +98,7 @@ a:hover {
 	width: 32px;
 	height: 32px;
 	border-radius: 50%;
-	background: rgba(255, 255, 255, 0.15);
+	background: var(--primary);
 	color: #fff;
 	transition: all 0.2s ease;
 }
@@ -471,211 +120,13 @@ a:hover {
 	background: linear-gradient(45deg, #f09433, #e6683c, #dc2743, #cc2366, #bc1888);
 }
 
-/* Карточка тренера в списке - социальные ссылки */
-.trainer-list-card .social-link {
-	background: var(--primary);
-	color: #fff;
-	width: 28px;
-	height: 28px;
-}
+/* ===========================
+   ANT DESIGN МИНИМАЛЬНЫЕ ФИКСЫ
+   (только то, что нельзя настроить через ConfigProvider)
+   =========================== */
 
-.trainer-list-card .social-link:hover {
-	color: #fff;
-}
-
-/* === ANT DESIGN NOTIFICATION (v5+) === */
-.ant-notification-notice,
-.ant-notification-notice-wrapper .ant-notification-notice {
-	background: #ffffff !important;
-	background-color: #ffffff !important;
-	border: 1px solid #e5e7eb !important;
-	border-radius: 12px !important;
-	box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15) !important;
-}
-
-.ant-notification-notice-message,
-.ant-notification-notice-wrapper .ant-notification-notice-message {
-	color: #1f2937 !important;
-	font-weight: 600 !important;
-}
-
-.ant-notification-notice-description,
-.ant-notification-notice-wrapper .ant-notification-notice-description {
-	color: #6b7280 !important;
-}
-
-.ant-notification-notice-icon,
-.ant-notification-notice-wrapper .ant-notification-notice-icon {
-	color: #f59e0b !important;
-}
-
-.ant-notification-notice-close,
-.ant-notification-notice-wrapper .ant-notification-notice-close {
-	color: #6b7280 !important;
-}
-
-.ant-notification-notice-close:hover,
-.ant-notification-notice-wrapper .ant-notification-notice-close:hover {
-	color: #1f2937 !important;
-}
-
-/* === ANT DESIGN MESSAGE (v5+) === */
-.ant-message .ant-message-notice-content,
-.ant-message-notice-content {
-	background: #ffffff !important;
-	background-color: #ffffff !important;
-	color: #1f2937 !important;
-	border: 1px solid #e5e7eb !important;
-	border-radius: 8px !important;
-	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15) !important;
-}
-
-.ant-message .ant-message-notice-content .anticon,
-.ant-message-notice-content .anticon {
-	color: inherit !important;
-}
-
-/* Фикс для message wrapper */
-.ant-message-notice-wrapper {
-	background: transparent !important;
-}
-
-/* Цвета для разных типов сообщений */
-.ant-message-success .ant-message-notice-content {
-	border-left: 4px solid #10b981 !important;
-}
-
-.ant-message-error .ant-message-notice-content {
-	border-left: 4px solid #ef4444 !important;
-}
-
-.ant-message-warning .ant-message-notice-content {
-	border-left: 4px solid #f59e0b !important;
-}
-
-.ant-message-info .ant-message-notice-content {
-	border-left: 4px solid #3b82f6 !important;
-}
-
-/* === FIX: Alert компонент для Ant Design v5 === */
-.ant-alert {
-	background: #ffffff !important;
-	background-color: #ffffff !important;
-	border-radius: 8px !important;
-}
-
-.ant-alert-error {
-	background: #fff2f0 !important;
-	background-color: #fff2f0 !important;
-	border: 1px solid #ffccc7 !important;
-}
-
-.ant-alert-error .ant-alert-message {
-	color: #a8071a !important;
-}
-
-.ant-alert-error .ant-alert-description {
-	color: #cf1322 !important;
-}
-
-.ant-alert-error .ant-alert-icon {
-	color: #ff4d4f !important;
-}
-
-.ant-alert-warning {
-	background: #fffbe6 !important;
-	background-color: #fffbe6 !important;
-	border: 1px solid #ffe58f !important;
-}
-
-.ant-alert-warning .ant-alert-message {
-	color: #ad6800 !important;
-}
-
-.ant-alert-success {
-	background: #f6ffed !important;
-	background-color: #f6ffed !important;
-	border: 1px solid #b7eb8f !important;
-}
-
-.ant-alert-success .ant-alert-message {
-	color: #389e0d !important;
-}
-
-.ant-alert-info {
-	background: #e6f4ff !important;
-	background-color: #e6f4ff !important;
-	border: 1px solid #91caff !important;
-}
-
-.ant-alert-info .ant-alert-message {
-	color: #0958d9 !important;
-}
-
-.ant-alert-close-icon {
-	color: rgba(0, 0, 0, 0.45) !important;
-}
-
-.ant-alert-close-icon:hover {
-	color: rgba(0, 0, 0, 0.88) !important;
-}
-
-/* === FIX: Notification wrapper для Ant Design v5 === */
-.ant-notification {
-	z-index: 9999 !important;
-}
-
-.ant-notification-notice-wrapper {
-	background: transparent !important;
-}
-
-/* Принудительные стили для notification в Ant Design v5 */
-div[class*='ant-notification'] .ant-notification-notice {
-	background: #ffffff !important;
-	background-color: #ffffff !important;
-	border: 1px solid #e5e7eb !important;
-	border-radius: 12px !important;
-	box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15) !important;
-}
-
-div[class*='ant-notification'] .ant-notification-notice-message {
-	color: #1f2937 !important;
-	font-weight: 600 !important;
-}
-
-div[class*='ant-notification'] .ant-notification-notice-description {
-	color: #4b5563 !important;
-}
-
-div[class*='ant-notification'] .ant-notification-notice-icon {
-	color: #f59e0b !important;
-}
-
-div[class*='ant-notification'] .ant-notification-notice-close {
-	color: #6b7280 !important;
-}
-
-div[class*='ant-notification'] .ant-notification-notice-close:hover {
-	color: #1f2937 !important;
-	background: #f3f4f6 !important;
-}
-
-.ant-collapse-content-box > :last-child {
-	margin-bottom: 0;
-}
-
-.nutrition-days-container > * {
-	margin-bottom: 1.5rem; /* 24px */
-}
-
-.nutrition-days-container > *:last-child {
-	margin-bottom: 0;
-}
-
-/* === HEADER DROPDOWN MENU === */
+/* Dropdown меню - позиционирование и анимация */
 .ant-dropdown-menu {
-	background: var(--bg-light) !important;
-	border: 1px solid var(--border) !important;
 	border-radius: 12px !important;
 	box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15) !important;
 	padding: 4px !important;
@@ -684,51 +135,35 @@ div[class*='ant-notification'] .ant-notification-notice-close:hover {
 .ant-dropdown-menu-item {
 	border-radius: 8px !important;
 	margin: 2px 0 !important;
-	padding: 8px 12px !important;
 	transition: all 0.2s ease !important;
 }
 
-.ant-dropdown-menu-item:hover {
-	background: var(--primary) !important;
+/* Select dropdown - скругления */
+.ant-select-dropdown {
+	border-radius: 12px !important;
+	box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15) !important;
 }
 
-.ant-dropdown-menu-item:hover .ant-dropdown-menu-title-content,
-.ant-dropdown-menu-item:hover .anticon {
-	color: #ffffff !important;
+.ant-select-item {
+	border-radius: 6px !important;
+	margin: 2px 8px !important;
 }
 
-.ant-dropdown-menu-item-danger:hover {
-	background: var(--danger) !important;
+/* DatePicker dropdown */
+.ant-picker-dropdown {
+	border-radius: 12px !important;
 }
 
-.ant-dropdown-menu-item-danger:hover .ant-dropdown-menu-title-content,
-.ant-dropdown-menu-item-danger:hover .anticon {
-	color: #ffffff !important;
+/* Notification и Message - z-index и позиционирование */
+.ant-notification {
+	z-index: 9999 !important;
 }
 
-/* Активные ссылки в навигации */
-.nav-link-active {
-	color: var(--primary) !important;
-	font-weight: 600 !important;
+.ant-message {
+	z-index: 9999 !important;
 }
 
-/* Action buttons in cards */
-.action-buttons {
-	display: flex;
-	justify-content: space-between;
-	gap: 8px;
-}
-
-.action-buttons button {
-	width: 100%;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-
-@media (max-width: 720px) {
-	.action-buttons {
-		flex-direction: column;
-		align-items: stretch;
-	}
+/* Collapse - убираем лишние отступы */
+.ant-collapse-content-box > :last-child {
+	margin-bottom: 0;
 }

--- a/frontend/src/pages/auth/Registration.tsx
+++ b/frontend/src/pages/auth/Registration.tsx
@@ -222,8 +222,8 @@ export const Registration = () => {
 	}
 
 	return (
-		<div className='auth-container gradient-bg'>
-			<div className='auth-card' style={{ maxWidth: '800px' }}>
+		<div className='gradient-bg min-h-[calc(100vh-4rem)] flex items-center justify-center p-5'>
+			<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 max-w-[800px] w-full'>
 				<div className='text-center mb-8'>
 					<Title>Создать аккаунт</Title>
 					<Text type='secondary' className='text-lg'>
@@ -242,8 +242,8 @@ export const Registration = () => {
 					scrollToFirstError
 				>
 					{/* Секция фото */}
-					<div className='form-section'>
-						<Title level={4} className='section-title'>
+					<div className='mb-8'>
+						<Title level={4} className='text-gray-800 font-semibold mb-4 pb-3 border-b-2 border-primary inline-block'>
 							<CameraOutlined className='mr-2' />
 							Фотографии для анализа
 						</Title>
@@ -251,9 +251,9 @@ export const Registration = () => {
 							Загрузите три фотографии для точного анализа телосложения
 						</Text>
 
-						<div className='photo-upload-grid'>
+						<div className='grid grid-cols-2 gap-4 mb-6'>
 							{photoFields.map((photoType, index) => (
-								<div key={photoType} className='upload-area'>
+								<div key={photoType} className='border-2 border-dashed border-gray-300 rounded-xl p-5 text-center cursor-pointer transition-all hover:border-primary hover:bg-gray-50'>
 									<Form.Item
 										name={photoType}
 										valuePropName='file'
@@ -320,8 +320,8 @@ export const Registration = () => {
 					</div>
 
 					{/* Личная информация */}
-					<div className='form-section'>
-						<Title level={4} className='section-title'>
+					<div className='mb-8'>
+						<Title level={4} className='text-gray-800 font-semibold mb-4 pb-3 border-b-2 border-primary inline-block'>
 							👤 Личная информация
 						</Title>
 
@@ -364,8 +364,8 @@ export const Registration = () => {
 					</div>
 
 					{/* Физические параметры */}
-					<div className='form-section'>
-						<Title level={4} className='section-title'>
+					<div className='mb-8'>
+						<Title level={4} className='text-gray-800 font-semibold mb-4 pb-3 border-b-2 border-primary inline-block'>
 							📏 Физические параметры
 						</Title>
 
@@ -399,8 +399,8 @@ export const Registration = () => {
 					</div>
 
 					{/* Замеры тела */}
-					<div className='form-section'>
-						<Title level={4} className='section-title'>
+					<div className='mb-8'>
+						<Title level={4} className='text-gray-800 font-semibold mb-4 pb-3 border-b-2 border-primary inline-block'>
 							📐 Замеры тела (см)
 						</Title>
 
@@ -473,8 +473,8 @@ export const Registration = () => {
 					</div>
 
 					{/* Фитнес цели */}
-					<div className='form-section'>
-						<Title level={4} className='section-title'>
+					<div className='mb-8'>
+						<Title level={4} className='text-gray-800 font-semibold mb-4 pb-3 border-b-2 border-primary inline-block'>
 							🎯 Фитнес информация
 						</Title>
 
@@ -528,8 +528,8 @@ export const Registration = () => {
 					</div>
 
 					{/* Пароль */}
-					<div className='form-section'>
-						<Title level={4} className='section-title'>
+					<div className='mb-8'>
+						<Title level={4} className='text-gray-800 font-semibold mb-4 pb-3 border-b-2 border-primary inline-block'>
 							🔐 Безопасность
 						</Title>
 						<Form.Item

--- a/frontend/src/pages/client/AddProgress.tsx
+++ b/frontend/src/pages/client/AddProgress.tsx
@@ -139,11 +139,11 @@ export const AddProgress = () => {
 	}
 
 	return (
-		<div className='page-container gradient-bg'>
-			<div className='page-card' style={{ maxWidth: '700px' }}>
+		<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+			<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[700px]'>
 				<Card className='!border-gray-200'>
-					<div className='section-header mb-6'>
-						<Title level={2} className='section-title !mb-1'>
+					<div className='text-center mb-6'>
+						<Title level={2} className='text-gray-800 font-semibold mb-1 pb-3 border-b-3 border-primary inline-block'>
 							📊 Добавить прогресс
 						</Title>
 						<Text type='secondary'>
@@ -268,7 +268,7 @@ export const AddProgress = () => {
 						{/* Фото - опциональные */}
 						<div className='grid grid-cols-3 gap-4 mb-6'>
 							{photoFields.map((photoType, index) => (
-								<div key={photoType} className='upload-area'>
+								<div key={photoType} className='border-2 border-dashed border-gray-300 rounded-xl p-4 text-center cursor-pointer transition-all hover:border-primary hover:bg-gray-50'>
 									{photoPreviews[photoType] ? (
 										<div className='photo-preview-container'>
 											<img

--- a/frontend/src/pages/client/AllReports.tsx
+++ b/frontend/src/pages/client/AllReports.tsx
@@ -122,8 +122,8 @@ export const AllReports: FC = () => {
 
 	if (isLoading) {
 		return (
-			<div className='page-container gradient-bg'>
-				<div className='page-card flex justify-center items-center min-h-[400px]'>
+			<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+				<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[1200px] flex justify-center items-center min-h-[400px]'>
 					<Spin
 						indicator={<LoadingOutlined style={{ fontSize: 48 }} spin />}
 						tip='Загрузка отчетов...'
@@ -140,8 +140,8 @@ export const AllReports: FC = () => {
 				: 'Ошибка при загрузке отчетов'
 
 		return (
-			<div className='page-container gradient-bg'>
-				<div className='page-card'>
+			<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+				<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[1200px]'>
 					<Alert
 						message='Ошибка загрузки'
 						description={errorMessage}
@@ -155,10 +155,10 @@ export const AllReports: FC = () => {
 
 	if (reports.length === 0) {
 		return (
-			<div className='page-container gradient-bg'>
-				<div className='page-card'>
-					<div className='section-header'>
-						<Title level={2} className='section-title'>
+			<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+				<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[1200px]'>
+					<div className='text-center mb-8'>
+						<Title level={2} className='text-gray-800 font-semibold mb-4 pb-3 border-b-3 border-primary inline-block'>
 							📋 Ваши отчеты
 						</Title>
 					</div>
@@ -174,10 +174,10 @@ export const AllReports: FC = () => {
 	const paginated = filteredReports.slice((page - 1) * pageSize, page * pageSize)
 
 	return (
-		<div className='page-container gradient-bg'>
-			<div className='page-card'>
-				<div className='section-header'>
-					<Title level={2} className='section-title'>
+		<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+			<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[1200px]'>
+				<div className='text-center mb-8'>
+					<Title level={2} className='text-gray-800 font-semibold mb-4 pb-3 border-b-3 border-primary inline-block'>
 						📋 Ваши отчеты
 					</Title>
 				</div>

--- a/frontend/src/pages/client/Main.tsx
+++ b/frontend/src/pages/client/Main.tsx
@@ -180,7 +180,7 @@ export const Main: React.FC = () => {
 	// Загрузка (есть токен, но данные ещё грузятся)
 	if (isStillLoading) {
 		return (
-			<div className='page-container gradient-bg'>
+			<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
 				<div className='flex justify-center items-center py-20'>
 					<Spin size='large' />
 				</div>
@@ -191,8 +191,8 @@ export const Main: React.FC = () => {
 	// Неавторизованный пользователь - показываем лендинг
 	if (!isAuthenticated) {
 		return (
-			<div className='page-container gradient-bg'>
-				<div className='page-card text-center'>
+			<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+				<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[1200px] text-center'>
 					<Title level={1} className='text-6xl! font-black! mb-6! text-gray-800!'>
 						Fitness App
 					</Title>
@@ -216,8 +216,8 @@ export const Main: React.FC = () => {
 	// Тренер - показываем приветствие и переход в админку
 	if (user?.role === 'TRAINER') {
 		return (
-			<div className='page-container gradient-bg'>
-				<div className='page-card text-center'>
+			<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+				<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[1200px] text-center'>
 					<Title level={1} className='text-5xl! font-black! mb-6! text-gray-800!'>
 						👋 Добро пожаловать, {user.name}!
 					</Title>
@@ -240,10 +240,10 @@ export const Main: React.FC = () => {
 	// Клиент с привязанным тренером
 	if (hasTrainer && user.trainer) {
 		return (
-			<div className='page-container gradient-bg'>
-				<div className='page-card'>
-					<div className='section-header'>
-						<Title level={2} className='section-title mb-2!'>
+			<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+				<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[1200px]'>
+					<div className='text-center mb-8'>
+						<Title level={2} className='text-gray-800 font-semibold mb-4 pb-3 border-b-3 border-primary inline-block'>
 							🏋️ Ваш тренер
 						</Title>
 						<Paragraph className='text-gray-600! mb-0!'>
@@ -262,10 +262,10 @@ export const Main: React.FC = () => {
 					{availableTrainers.length > 0 && (
 						<>
 							<Divider />
-							<div className='section-header'>
+							<div className='text-center mb-8'>
 								<Title
 									level={3}
-									className='mb-2! flex! items-center! justify-center! gap-2!'
+									className='mb-2 flex items-center justify-center gap-2'
 								>
 									<TeamOutlined /> Другие тренеры
 								</Title>
@@ -304,10 +304,10 @@ export const Main: React.FC = () => {
 
 	// Клиент без тренера - показываем список тренеров с пагинацией
 	return (
-		<div className='page-container gradient-bg'>
-			<div className='page-card'>
-				<div className='section-header'>
-					<Title level={2} className='section-title mb-2!'>
+		<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+			<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[1200px]'>
+				<div className='text-center mb-8'>
+					<Title level={2} className='text-gray-800 font-semibold mb-4 pb-3 border-b-3 border-primary inline-block'>
 						🎯 Выберите тренера
 					</Title>
 					<Paragraph className='text-gray-600! mb-0!'>

--- a/frontend/src/pages/client/Nutrition.tsx
+++ b/frontend/src/pages/client/Nutrition.tsx
@@ -30,7 +30,7 @@ export const Nutrition: React.FC = () => {
 
 	if (isLoading) {
 		return (
-			<div className='page-container gradient-bg flex items-center justify-center min-h-[60vh]'>
+			<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex items-center justify-center'>
 				<Spin size='large' />
 			</div>
 		)
@@ -38,8 +38,8 @@ export const Nutrition: React.FC = () => {
 
 	if (isError) {
 		return (
-			<div className='page-container gradient-bg'>
-				<div className='page-card'>
+			<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+				<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[1200px]'>
 					<Alert
 						type='error'
 						message='Не удалось загрузить план питания'
@@ -53,9 +53,9 @@ export const Nutrition: React.FC = () => {
 
 	if (!plan || days.length === 0) {
 		return (
-			<div className='page-container gradient-bg'>
-				<div className='page-card'>
-					<Title level={2} className='section-title'>
+			<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+				<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[1200px]'>
+					<Title level={2} className='text-gray-800 font-semibold mb-4 pb-3 border-b-3 border-primary inline-block'>
 						🍽️ План питания
 					</Title>
 					<Alert
@@ -80,11 +80,11 @@ export const Nutrition: React.FC = () => {
 	// }
 
 	return (
-		<div className='page-container gradient-bg'>
-			<div className='page-card'>
-				<div className='section-header flex items-center justify-between gap-4 flex-wrap mb-6'>
+		<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+			<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[1200px]'>
+				<div className='flex items-center justify-between gap-4 flex-wrap mb-6'>
 					<div className='flex flex-col'>
-						<Title level={2} className='section-title m-0 text-left'>
+						<Title level={2} className='text-gray-800 font-semibold m-0 text-left pb-3 border-b-3 border-primary inline-block'>
 							🍽️ План питания
 						</Title>
 						{plan.subcategory && (
@@ -93,7 +93,6 @@ export const Nutrition: React.FC = () => {
 					</div>
 
 					<Segmented<FilterType>
-						className='custom-segmented'
 						options={[
 							{ label: 'День', value: 'day' },
 							{ label: 'Неделя', value: 'week' },
@@ -113,7 +112,7 @@ export const Nutrition: React.FC = () => {
 					</Text>
 				</div>
 
-				<div className='space-y-6 nutrition-days-container'>
+				<div className='space-y-6'>
 					{days.map((day) => (
 						<NutritionDayCard
 							key={day.id}

--- a/frontend/src/pages/client/PersonalAccount.tsx
+++ b/frontend/src/pages/client/PersonalAccount.tsx
@@ -261,8 +261,8 @@ export const PersonalAccount = () => {
 
 	if (error) {
 		return (
-			<div className='page-container gradient-bg'>
-				<div className='page-card' style={{ maxWidth: '500px' }}>
+			<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+				<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[500px]'>
 					<ErrorState
 						title='Ошибка загрузки'
 						message='Не удалось загрузить данные профиля'
@@ -276,8 +276,8 @@ export const PersonalAccount = () => {
 
 	if (!user) {
 		return (
-			<div className='page-container gradient-bg'>
-				<div className='page-card' style={{ maxWidth: '500px' }}>
+			<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+				<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[500px]'>
 					<ErrorState
 						title='Ошибка загрузки'
 						message='Пожалуйста, войдите в аккаунт'
@@ -303,10 +303,10 @@ export const PersonalAccount = () => {
 		firstWeight && lastWeight ? (lastWeight - firstWeight).toFixed(1) : null
 
 	return (
-		<div className='page-container gradient-bg'>
-			<div className='page-card' style={{ maxWidth: '1000px' }}>
-				<div className='section-header'>
-					<Title level={2} className='section-title mb-2!'>
+		<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+			<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[1000px]'>
+				<div className='text-center mb-8'>
+					<Title level={2} className='text-gray-800 font-semibold mb-2 pb-3 border-b-3 border-primary inline-block'>
 						👤 Мой профиль
 					</Title>
 				</div>

--- a/frontend/src/pages/client/Progress.tsx
+++ b/frontend/src/pages/client/Progress.tsx
@@ -31,8 +31,8 @@ export const Progress = () => {
 
   if (isLoading) {
     return (
-      <div className="page-container gradient-bg">
-        <div className="page-card">
+      <div className="gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start">
+        <div className="bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[1200px]">
           <div className="flex justify-center items-center h-64">
             <Spin size="large" />
           </div>
@@ -43,8 +43,8 @@ export const Progress = () => {
 
   if (error) {
     return (
-      <div className="page-container gradient-bg">
-        <div className="page-card">
+      <div className="gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start">
+        <div className="bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[1200px]">
           <Alert 
             message="Ошибка загрузки" 
             description="Не удалось загрузить данные о прогрессе"
@@ -107,10 +107,10 @@ export const Progress = () => {
   }
 
   return (
-    <div className='page-container gradient-bg'>
-      <div className='page-card'>
-        <div className='section-header'>
-          <Title level={2} className='section-title'>
+    <div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+      <div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[1200px]'>
+        <div className='text-center mb-8'>
+          <Title level={2} className='text-gray-800 font-semibold mb-4 pb-3 border-b-3 border-primary inline-block'>
             📈 Ваш прогресс
           </Title>
         </div>

--- a/frontend/src/pages/client/Report.tsx
+++ b/frontend/src/pages/client/Report.tsx
@@ -58,8 +58,8 @@ export const Report: FC = () => {
 
     if (!id) {
         return (
-            <div className='page-container gradient-bg'>
-                <div className='page-card'>
+            <div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+                <div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[1200px]'>
                     <Alert
                         message='Ошибка'
                         description='ID отчета не указан'
@@ -76,8 +76,8 @@ export const Report: FC = () => {
 
     if (isLoading) {
         return (
-            <div className='page-container gradient-bg'>
-                <div className='page-card flex justify-center items-center min-h-[400px]'>
+            <div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+                <div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[1200px] flex justify-center items-center min-h-[400px]'>
                     <Spin
                         indicator={<LoadingOutlined style={{ fontSize: 48 }} spin />}
                         tip='Загрузка отчета...'
@@ -94,8 +94,8 @@ export const Report: FC = () => {
                 : 'Ошибка при загрузке отчета'
 
         return (
-            <div className='page-container gradient-bg'>
-                <div className='page-card'>
+            <div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+                <div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[1200px]'>
                     <Alert
                         message='Ошибка загрузки'
                         description={errorMessage}
@@ -117,8 +117,8 @@ export const Report: FC = () => {
 
     if (!report) {
         return (
-            <div className='page-container gradient-bg'>
-                <div className='page-card'>
+            <div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+                <div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[1200px]'>
                     <Alert message='Отчет не найден' type='warning' showIcon />
                     <Button
                         type='primary'
@@ -139,8 +139,8 @@ export const Report: FC = () => {
     const hasAnyPhoto = showFront || showSide || showBack
 
     return (
-        <div className='page-container gradient-bg'>
-            <div className='page-card' style={{ maxWidth: '800px' }}>
+        <div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+            <div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[800px]'>
                 <Button
                     type='text'
                     icon={<ArrowLeftOutlined />}
@@ -151,8 +151,8 @@ export const Report: FC = () => {
                 </Button>
 
                 <Card>
-                    <div className='section-header'>
-                        <Title level={2} className='section-title'>
+                    <div className='text-center mb-8'>
+                        <Title level={2} className='text-gray-800 font-semibold mb-4 pb-3 border-b-3 border-primary inline-block'>
                             📄 Отчет от {formatDate(report.date)}
                         </Title>
                     </div>

--- a/frontend/src/pages/client/Trainer.tsx
+++ b/frontend/src/pages/client/Trainer.tsx
@@ -5,10 +5,10 @@ const { Title } = Typography
 
 export const Trainer = () => {
 	return (
-		<div className='page-container gradient-bg'>
-			<div className='page-card' style={{ maxWidth: '800px' }}>
-				<div className='section-header mb-4'>
-					<Title level={2} className='section-title !mb-1'>
+		<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+			<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[800px]'>
+				<div className='text-center mb-4'>
+					<Title level={2} className='text-gray-800 font-semibold mb-1 pb-3 border-b-3 border-primary inline-block'>
 						💬 Чат с тренером
 					</Title>
 				</div>

--- a/frontend/src/pages/trainer/AddNutritionTrainer.tsx
+++ b/frontend/src/pages/trainer/AddNutritionTrainer.tsx
@@ -235,8 +235,8 @@ export const AddNutritionTrainer = () => {
 
 	if (isErrorCategories) {
 		return (
-			<div className='page-container gradient-bg'>
-				<div className='page-card max-w-4xl'>
+			<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+				<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-4xl'>
 					<Empty
 						description='Ошибка при загрузке категорий питания'
 						image={Empty.PRESENTED_IMAGE_SIMPLE}
@@ -254,19 +254,19 @@ export const AddNutritionTrainer = () => {
 	const daysCount = selectAllDays ? days.length : selectedDayIds.length
 
 	return (
-		<div className='page-container gradient-bg'>
-			<div className='page-card max-w-5xl'>
+		<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+			<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-5xl'>
 				{/* Заголовок */}
-				<div className='section-header'>
+				<div className='text-center mb-8 relative'>
 					<Button
 						type='text'
 						icon={<ArrowLeftOutlined />}
 						onClick={handleCancel}
-						className='absolute! left-8! top-8!'
+						className='absolute left-0 top-0'
 					>
 						Назад
 					</Button>
-					<Title level={2} className='section-title'>
+					<Title level={2} className='text-gray-800 font-semibold mb-4 pb-3 border-b-3 border-primary inline-block'>
 						🍽️ Назначение плана питания
 					</Title>
 					<Paragraph type='secondary' className='max-w-xl mx-auto'>
@@ -275,7 +275,7 @@ export const AddNutritionTrainer = () => {
 				</div>
 
 				{/* Селекторы */}
-				<Card className='mb-6 card-hover'>
+				<Card className='mb-6 hover:shadow-lg transition-all duration-300'>
 					<div className='grid grid-cols-1 md:grid-cols-2 gap-6'>
 						{/* Категория */}
 						<div>
@@ -388,7 +388,7 @@ export const AddNutritionTrainer = () => {
 								<Spin size='large' />
 							</div>
 						) : days.length > 0 ? (
-							<div className='nutrition-days-container'>
+							<div className='space-y-6'>
 								{!selectAllDays && (
 									<div className='p-3 bg-yellow-50 rounded-lg border border-yellow-200 mb-4'>
 										<Text type='warning'>

--- a/frontend/src/pages/trainer/Admin.tsx
+++ b/frontend/src/pages/trainer/Admin.tsx
@@ -298,12 +298,11 @@ export const Admin: React.FC = () => {
 	]
 
 	return (
-		// <div className='gradient-bg min-h-screen'>
-			<Layout className='admin-layout bg-transparent'>
+			<Layout className='min-h-screen overflow-hidden bg-transparent'>
 				<Sider
 					width={sidebarCollapsed ? 80 : 300}
 					collapsed={sidebarCollapsed}
-					className='admin-sidebar'
+					className='bg-light! border-r border-gray-200 shadow-md h-screen overflow-y-auto'
 					theme='light'
 				>
 					<div className='p-4 border-b border-gray-200'>
@@ -324,12 +323,12 @@ export const Admin: React.FC = () => {
 					)}
 				</Sider>
 
-				<Content className='admin-content'>
-					<div className='admin-page-card'>
+				<Content className='h-screen overflow-y-auto bg-transparent! p-0!'>
+					<div className='bg-light p-10 shadow-xl w-full min-h-full'>
 						{/* Header */}
 						<div className='flex items-center justify-between mb-6'>
-							<div className='section-header mb-0! text-left!'>
-								<Title level={2} className='section-title mb-0!'>
+							<div className='text-left'>
+								<Title level={2} className='text-gray-800 font-semibold mb-0 pb-3 border-b-3 border-primary inline-block'>
 									🏢 Панель тренера
 								</Title>
 								<Text type='secondary' className='block mt-1'>
@@ -356,6 +355,5 @@ export const Admin: React.FC = () => {
 					</div>
 				</Content>
 			</Layout>
-		// </div>
 	)
 }

--- a/frontend/src/pages/trainer/ChatWithClient.tsx
+++ b/frontend/src/pages/trainer/ChatWithClient.tsx
@@ -16,15 +16,15 @@ export const ChatWithClient = () => {
 	const clientName = client?.name || `Клиент #${id?.slice(-4) || ''}`
 
 	return (
-		<div className='page-container gradient-bg'>
-			<div className='page-card' style={{ maxWidth: '800px' }}>
-				<div className='section-header mb-4 flex items-center gap-4'>
+		<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+			<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[800px]'>
+				<div className='mb-4 flex items-center gap-4'>
 					<Button
 						icon={<ArrowLeftOutlined />}
 						onClick={() => navigate('/admin')}
 						type='text'
 					/>
-					<Title level={2} className='section-title !mb-0'>
+					<Title level={2} className='text-gray-800 font-semibold mb-0 pb-3 border-b-3 border-primary inline-block'>
 						💬 {clientName}
 					</Title>
 				</div>

--- a/frontend/src/pages/trainer/ClientProfile.tsx
+++ b/frontend/src/pages/trainer/ClientProfile.tsx
@@ -55,8 +55,8 @@ export const ClientProfile = () => {
 
 	if (clientError || !clientData) {
 		return (
-			<div className='page-container gradient-bg'>
-				<div className='page-card' style={{ maxWidth: '500px' }}>
+			<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+				<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[500px]'>
 					<ErrorState
 						title='Ошибка загрузки'
 						message='Не удалось загрузить данные клиента'
@@ -69,10 +69,10 @@ export const ClientProfile = () => {
 	}
 
 	return (
-		<div className='page-container gradient-bg'>
-			<div className='page-card'>
-				<div className='section-header'>
-					<Title level={2} className='section-title'>
+		<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+			<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[1200px]'>
+				<div className='text-center mb-8'>
+					<Title level={2} className='text-gray-800 font-semibold mb-4 pb-3 border-b-3 border-primary inline-block'>
 						Профиль клиента
 					</Title>
 				</div>
@@ -84,7 +84,7 @@ export const ClientProfile = () => {
 
 					<Col xs={24} lg={16}>
 						<div className='flex flex-col h-full gap-6'>
-							<Card className='card-hover flex-1 flex flex-col'>
+							<Card className='hover:shadow-lg transition-all duration-300 hover:-translate-y-1 flex-1 flex flex-col'>
 								{progressLoading ? (
 									<div className='flex justify-center py-8'>
 										<LoadingState />
@@ -114,15 +114,15 @@ export const ClientProfile = () => {
 					</Col>
 				</Row>
 
-				<Card className='card-hover !mb-8'>
-					<Title level={4} className='section-title !text-lg !mb-6'>
+				<Card className='hover:shadow-lg transition-all duration-300 hover:-translate-y-1 !mb-8'>
+					<Title level={4} className='text-gray-800 font-semibold text-lg mb-6 pb-3 border-b-3 border-primary inline-block'>
 						График прогресса
 					</Title>
 					<ProgressChart data={progressData} metrics={PROGRESS_METRICS} />
 				</Card>
 
 				<Card>
-					<Title level={4} className='section-title !text-lg !mb-6'>
+					<Title level={4} className='text-gray-800 font-semibold text-lg mb-6 pb-3 border-b-3 border-primary inline-block'>
 						Комментарии
 					</Title>
 					<CommentsSection

--- a/frontend/src/pages/trainer/CreateNutritionTrainer.tsx
+++ b/frontend/src/pages/trainer/CreateNutritionTrainer.tsx
@@ -205,8 +205,8 @@ export const CreateNutritionTrainer = () => {
 	}
 
 	return (
-		<div className='page-container gradient-bg'>
-			<div className='page-card max-w-4xl mx-auto'>
+		<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+			<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-4xl'>
 				{/* Header */}
 				<div className='flex items-center gap-4 mb-6'>
 					<Button

--- a/frontend/src/pages/trainer/NutritionPlanTrainer.tsx
+++ b/frontend/src/pages/trainer/NutritionPlanTrainer.tsx
@@ -168,8 +168,8 @@ export const NutritionPlanTrainer = () => {
 
 	if (isError) {
 		return (
-			<div className='page-container gradient-bg'>
-				<div className='page-card'>
+			<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+				<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[1200px]'>
 					<Empty
 						description='Ошибка при загрузке дней'
 						image={Empty.PRESENTED_IMAGE_SIMPLE}
@@ -184,8 +184,8 @@ export const NutritionPlanTrainer = () => {
 	}
 
 	return (
-		<div className='page-container gradient-bg'>
-			<div className='page-card max-w-4xl mx-auto'>
+		<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+			<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-4xl'>
 				{/* Breadcrumb */}
 				<Breadcrumb
 					className='mb-4'

--- a/frontend/src/pages/trainer/NutritionTrainer.tsx
+++ b/frontend/src/pages/trainer/NutritionTrainer.tsx
@@ -138,8 +138,8 @@ export const NutritionTrainer = () => {
 
 	if (isErrorCategories) {
 		return (
-			<div className='page-container gradient-bg'>
-				<div className='page-card'>
+			<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+				<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-[1200px]'>
 					<div className='text-center py-12'>
 						<Empty
 							description='Ошибка при загрузке категорий'
@@ -156,12 +156,12 @@ export const NutritionTrainer = () => {
 	}
 
 	return (
-		<div className='page-container gradient-bg'>
-			<div className='page-card max-w-6xl mx-auto'>
+		<div className='gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start'>
+			<div className='bg-light rounded-2xl p-10 shadow-xl border border-gray-200 w-full max-w-6xl'>
 				{/* Header */}
 				<div className='flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-8'>
 					<div>
-						<Title level={2} className='section-title m-0!'>
+						<Title level={2} className='text-gray-800 font-semibold m-0 pb-3 border-b-3 border-primary inline-block'>
 							📚 Библиотека планов питания
 						</Title>
 						<Text type='secondary' className='text-sm mt-1 block'>
@@ -207,11 +207,11 @@ export const NutritionTrainer = () => {
 
 				{/* Categories */}
 				{filteredCategories.length > 0 ? (
-					<div className='space-y-6!'>
+					<div className='space-y-6'>
 						{filteredCategories.map((category: NutritionCategory) => (
 							<Card
 								key={category.id}
-								className='overflow-hidden mb-0!'
+								className='overflow-hidden'
 								title={
 									<div className='flex justify-between items-center'>
 										<div className='flex items-center gap-3'>

--- a/frontend/src/router/GuestRoute.tsx
+++ b/frontend/src/router/GuestRoute.tsx
@@ -28,7 +28,7 @@ export const GuestRoute: React.FC<GuestRouteProps> = ({ children }) => {
 	// Есть токен, но данные ещё загружаются
 	if (isLoading) {
 		return (
-			<div className="page-container gradient-bg">
+			<div className="gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start">
 				<div className="flex justify-center items-center py-20">
 					<Spin size="large" />
 				</div>

--- a/frontend/src/router/ProtectedRoute.tsx
+++ b/frontend/src/router/ProtectedRoute.tsx
@@ -28,7 +28,7 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
 	// Загрузка данных пользователя
 	if (isLoading) {
 		return (
-			<div className="page-container gradient-bg">
+			<div className="gradient-bg min-h-[calc(100vh-4rem)] p-10 flex justify-center items-start">
 				<div className="flex justify-center items-center py-20">
 					<Spin size="large" />
 				</div>

--- a/frontend/theme-config.ts
+++ b/frontend/theme-config.ts
@@ -1,39 +1,64 @@
+import type { ThemeConfig } from 'antd'
 import { theme } from 'antd'
 
-export const customTheme = {
+export const customTheme: ThemeConfig = {
 	algorithm: theme.defaultAlgorithm,
 	token: {
+		// Основные цвета
 		colorPrimary: 'var(--primary)',
 		colorSuccess: 'var(--success)',
 		colorWarning: 'var(--warning)',
 		colorError: 'var(--danger)',
 		colorInfo: 'var(--info)',
-		colorBgLayout: 'var(--bg-dark)',
+
+		// Фоны
+		colorBgLayout: 'var(--bg)',
 		colorBgContainer: 'var(--bg-light)',
 		colorBgElevated: 'var(--bg-light)',
+		colorBgSpotlight: 'var(--bg-dark)',
+
+		// Текст
 		colorText: 'var(--text)',
 		colorTextSecondary: 'var(--text-muted)',
+		colorTextTertiary: 'var(--text-muted)',
+		colorTextQuaternary: 'var(--text-muted)',
 		colorTextHeading: 'var(--text)',
+
+		// Границы
 		colorBorder: 'var(--border)',
 		colorBorderSecondary: 'var(--border-muted)',
+
+		// Hover/Active состояния
 		colorPrimaryHover: 'var(--info)',
 		colorPrimaryActive: 'var(--primary)',
+
+		// Заливки
+		colorFill: 'var(--bg)',
 		colorFillSecondary: 'var(--bg)',
 		colorFillTertiary: 'var(--bg-dark)',
 		colorFillQuaternary: 'var(--bg-light)',
 
-		borderRadius: 6,
+		// Скругления
+		borderRadius: 8,
+		borderRadiusLG: 12,
+		borderRadiusSM: 6,
+
+		// Тени
+		boxShadow: '0 4px 12px rgba(0, 0, 0, 0.08)',
+		boxShadowSecondary: '0 8px 25px rgba(0, 0, 0, 0.12)',
 	},
 	components: {
 		Layout: {
-			bodyBg: 'var(--bg-dark)',
+			bodyBg: 'var(--bg)',
 			headerBg: 'var(--bg-light)',
+			siderBg: 'var(--bg-light)',
 			triggerBg: 'var(--primary)',
 			triggerColor: 'var(--highlight)',
 		},
 		Card: {
 			colorBgContainer: 'var(--bg-light)',
 			colorBorderSecondary: 'var(--border-muted)',
+			borderRadiusLG: 16,
 		},
 		Button: {
 			colorPrimary: 'var(--primary)',
@@ -48,6 +73,8 @@ export const customTheme = {
 			primaryShadow: 'none',
 			textHoverBg: 'var(--bg)',
 			linkHoverBg: 'transparent',
+			borderRadius: 8,
+			controlHeight: 40,
 		},
 		Input: {
 			colorBgContainer: 'var(--bg-light)',
@@ -57,6 +84,7 @@ export const customTheme = {
 			hoverBorderColor: 'var(--primary)',
 			activeBorderColor: 'var(--primary)',
 			addonBg: 'var(--bg)',
+			borderRadius: 8,
 		},
 		InputNumber: {
 			colorBgContainer: 'var(--bg-light)',
@@ -65,6 +93,7 @@ export const customTheme = {
 			colorPrimary: 'var(--primary)',
 			hoverBorderColor: 'var(--primary)',
 			activeBorderColor: 'var(--primary)',
+			borderRadius: 8,
 		},
 		DatePicker: {
 			colorBgContainer: 'var(--bg-light)',
@@ -73,6 +102,7 @@ export const customTheme = {
 			colorPrimary: 'var(--primary)',
 			hoverBorderColor: 'var(--primary)',
 			activeBorderColor: 'var(--primary)',
+			borderRadius: 8,
 		},
 		Select: {
 			colorBgContainer: 'var(--bg-light)',
@@ -81,10 +111,12 @@ export const customTheme = {
 			colorPrimaryHover: 'var(--primary)',
 			optionSelectedBg: 'var(--bg)',
 			optionActiveBg: 'var(--bg-dark)',
+			borderRadius: 8,
 		},
 		Checkbox: {
 			colorPrimary: 'var(--primary)',
 			colorBgContainer: 'var(--bg-light)',
+			borderRadiusSM: 4,
 		},
 		Radio: {
 			colorPrimary: 'var(--primary)',
@@ -92,29 +124,32 @@ export const customTheme = {
 		},
 		Menu: {
 			colorPrimary: 'var(--primary)',
-			itemSelectedBg: 'var(--bg-dark)',
+			itemSelectedBg: 'var(--bg)',
 			itemHoverBg: 'var(--bg)',
 			itemColor: 'var(--text)',
 			itemSelectedColor: 'var(--primary)',
 			itemHoverColor: 'var(--primary)',
+			itemBorderRadius: 8,
 		},
 		Table: {
 			colorBgContainer: 'var(--bg-light)',
 			borderColor: 'var(--border-muted)',
-			headerBg: 'var(--bg-dark)',
+			headerBg: 'var(--bg)',
 			headerColor: 'var(--text)',
 			headerSplitColor: 'var(--border-muted)',
 			rowHoverBg: 'var(--bg)',
+			borderRadius: 12,
 		},
 		Modal: {
 			colorBgContainer: 'var(--bg-light)',
 			colorBgElevated: 'var(--bg-light)',
 			headerBg: 'var(--bg-light)',
+			contentBg: 'var(--bg-light)',
+			borderRadiusLG: 16,
 		},
 		Drawer: {
 			colorBgContainer: 'var(--bg-light)',
 			colorBgElevated: 'var(--bg-light)',
-			headerBg: 'var(--bg-light)',
 		},
 		Tabs: {
 			colorBgContainer: 'transparent',
@@ -127,34 +162,92 @@ export const customTheme = {
 		Form: {
 			labelColor: 'var(--text)',
 			labelRequiredMarkColor: 'var(--danger)',
-			itemMarginBottom: 16,
-			errorItemBg: 'transparent',
+			itemMarginBottom: 20,
 		},
 		Alert: {
-			colorErrorBg: 'var(--bg-dark)',
-			colorErrorBorder: 'var(--danger)',
-			colorError: 'var(--danger)',
-			colorWarningBg: 'var(--bg-dark)',
-			colorWarningBorder: 'var(--warning)',
-			colorWarning: 'var(--warning)',
-			colorSuccessBg: 'var(--bg-dark)',
-			colorSuccessBorder: 'var(--success)',
-			colorSuccess: 'var(--success)',
-			colorInfoBg: 'var(--bg-dark)',
-			colorInfoBorder: 'var(--info)',
-			colorInfo: 'var(--info)',
+			colorErrorBg: '#fff2f0',
+			colorErrorBorder: '#ffccc7',
+			colorWarningBg: '#fffbe6',
+			colorWarningBorder: '#ffe58f',
+			colorSuccessBg: '#f6ffed',
+			colorSuccessBorder: '#b7eb8f',
+			colorInfoBg: '#e6f4ff',
+			colorInfoBorder: '#91caff',
+			borderRadiusLG: 8,
+		},
+		Notification: {
+			colorBgElevated: '#ffffff',
+			colorText: 'var(--text)',
+			colorTextHeading: 'var(--text)',
+			borderRadiusLG: 12,
+		},
+		Message: {
+			colorBgElevated: '#ffffff',
+			colorText: 'var(--text)',
+			borderRadiusLG: 8,
 		},
 		Tooltip: {
-			colorBgSpotlight: 'var(--danger)',
+			colorBgSpotlight: 'var(--bg-dark)',
 			colorText: 'var(--highlight)',
+			borderRadius: 8,
 		},
-
+		Dropdown: {
+			colorBgElevated: 'var(--bg-light)',
+			controlItemBgHover: 'var(--primary)',
+			controlItemBgActive: 'var(--primary)',
+			borderRadiusLG: 12,
+		},
 		List: {
 			colorBgContainer: 'var(--bg-light)',
 			colorBorder: 'var(--border)',
 		},
 		Descriptions: {
 			colorBgContainer: 'var(--bg-light)',
+		},
+		Tag: {
+			borderRadiusSM: 6,
+		},
+		Badge: {
+			colorBgContainer: 'var(--danger)',
+		},
+		Pagination: {
+			colorPrimary: 'var(--primary)',
+			colorPrimaryHover: 'var(--info)',
+			borderRadius: 8,
+		},
+		Segmented: {
+			colorBgLayout: 'var(--bg)',
+			colorBgElevated: 'var(--bg-light)',
+			itemSelectedBg: 'var(--primary)',
+			itemSelectedColor: 'var(--highlight)',
+			borderRadius: 8,
+		},
+		Collapse: {
+			colorBgContainer: 'var(--bg-light)',
+			headerBg: 'var(--bg)',
+			borderRadiusLG: 12,
+		},
+		Empty: {
+			colorText: 'var(--text-muted)',
+			colorTextDescription: 'var(--text-muted)',
+		},
+		Spin: {
+			colorPrimary: 'var(--primary)',
+		},
+		Divider: {
+			colorSplit: 'var(--border-muted)',
+		},
+		Avatar: {
+			colorBgContainer: 'var(--bg)',
+		},
+		Skeleton: {
+			colorFill: 'var(--bg)',
+			colorFillContent: 'var(--border-muted)',
+		},
+		Upload: {
+			colorBgContainer: 'var(--bg-light)',
+			colorBorder: 'var(--border)',
+			colorPrimaryHover: 'var(--primary)',
 		},
 	},
 }


### PR DESCRIPTION
#343 

1. Сокращён index.css с 735 до 170 строк (в 4.3 раза меньше)

Оставлено:

CSS-переменные для темы (~30 строк)
Базовые стили body/a (~10 строк)
Кастомные Tailwind утилиты через @utility (~35 строк) — для использования CSS-переменных в Tailwind классах
Стили социальных ссылок (~30 строк)
Минимальные фиксы Ant Design (~40 строк) — только то, что нельзя настроить через ConfigProvider
Удалено:
~400 строк переопределений Ant Design компонентов с !important
Дублирующие утилитарные классы
Кастомные классы .page-container, .page-card, .section-title, .auth-card и т.д.

2. Расширен theme-config.ts

Добавлена полная настройка темы для всех компонентов Ant Design:
Notification, Message, Alert — с правильными цветами
Dropdown, Segmented, Collapse, Pagination
Upload, Avatar, Skeleton, Divider
И многие другие
Теперь большинство стилей Ant Design настраиваются через API, а не через CSS-хаки.

3. Обновлены все компоненты

Заменены кастомные классы на Tailwind:

4. Созданы кастомные Tailwind утилиты

Через директиву @utility (Tailwind CSS v4):
gradient-bg — градиентный фон страниц
bg-light — светлый фон
text-muted — приглушённый текст
border-muted — приглушённая граница
text-primary, border-primary — использование CSS-переменных
